### PR TITLE
NoEscape turned off by default

### DIFF
--- a/lib/pychess/ic/managers/ChatManager.py
+++ b/lib/pychess/ic/managers/ChatManager.py
@@ -112,6 +112,7 @@ class ChatManager (GObject.GObject):
         self.connection.lvm.setVariable("ctell", 1)
         self.connection.lvm.setVariable("tell", 1)
         self.connection.lvm.setVariable("height", 240)
+        self.connection.lvm.setVariable("noescape", 0)
         
         self.connection.client.run_command("inchannel %s" % self.connection.username)
         self.connection.client.run_command("help channel_list")


### PR DESCRIPTION
It is agitating if one loses a game on FICS simply because he disconnected (lost connection...etc). Setting noescape to off will try to avoid this problem and the user will not lose the game after losing connection but instead..the game will be adjourned and the user may either resign, abort, offer a draw or continue the game after this, leading to a more comfortable experience on PyChess. 

No functional change.