### PR TITLE
Error to install pychess win32: python setup.py install

### DIFF
--- a/lib/pychess/widgets/SetupBoard.py
+++ b/lib/pychess/widgets/SetupBoard.py
@@ -1,5 +1,6 @@
 
-from gi.repository import Gtk, Gtk.Gdk
+from gi.repository import Gtk
+from gi.repository.Gtk import Gdk
 from gi.repository import GObject
 
 from math import floor

--- a/pychess-engine.spec
+++ b/pychess-engine.spec
@@ -17,6 +17,8 @@ if platform.system() == "Windows":
     excludes = [(module, "'c:\\python27\\DLLs\\%s.pyd" % module, 'EXTENSION') for module in modules]
     name += ".exe"
     console = False
+    data = [('pychess_book.bin', "..\\pychess\\pychess_book.bin", 'DATA')]
+
 else:
     modules = ("_codecs_cn", "_codecs_hk", "_codecs_iso2022", "_codecs_jp", "_codecs_kr", "_codecs_tw",
                "_multibytecodecs", "_ssl", "audioop", "bz2", "unicodedata")
@@ -25,8 +27,7 @@ else:
     libs = ("libcrypto.so.1.0.0", "libssl.so.1.0.0")
     excludes += [(lib, "/usr/lib/%s" % lib, "BINARY") for lib in libs]
     console = True
-
-data = [('pychess_book.bin', "%s/pychess/pychess_book.bin" % home, 'DATA')]
+    data = [('pychess_book.bin', "%s/pychess/pychess_book.bin" % home, 'DATA')]
 
 exe = EXE(pyz,
           a.scripts,

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,14 @@ if sys.version_info < (2, 6, 0):
     print('ERROR: PyChess requires Python >= 2.6')
     sys.exit(1)
 
+if sys.platform == "win32":
+    try:
+        from gi.repository import Gtk
+    except ImportError:
+        print('ERROR: PyChess in Windows Platform requires to install PyGObject.')
+        print('Installing from http://sourceforge.net/projects/pygobjectwin32')
+        sys.exit(1)
+
 # To run "setup.py register" change name to "NAME+VERSION_NAME"
 # because pychess from another author already exist in pypi.
 VERSION = pychess.VERSION
@@ -88,7 +96,7 @@ sys.stderr = stderr
 sys.stdout = stdout
 
 DATA_FILES = [("share/pychess",
-    ["README", "AUTHORS", "ARTISTS", "DOCUMENTERS", "LICENSE", "TRANSLATORS", "pychess_book.bin", "eco.db"])]
+    ["README.md", "AUTHORS", "ARTISTS", "DOCUMENTERS", "LICENSE", "TRANSLATORS", "pychess_book.bin", "eco.db"])]
 
 # UI
 DATA_FILES += [("share/pychess/glade", glob('glade/*.glade'))]


### PR DESCRIPTION
Hi Tamas,
Congratulations on the great work for the pychess.
I found some problems installing the windows pychess, see below.

lib\pychess\widgets\SetupBoard.py:
byte-compiling C:\Python27\Lib\site-packages\pychess\widgets\SetupBoard.py to SetupBoard.pyc
  File "C:\Python27\Lib\site-packages\pychess\widgets\SetupBoard.py", line 2
    from gi.repository import Gtk, Gtk.Gdk
                                      ^
SyntaxError: invalid syntax

setup.py:
error: can't copy 'README': doesn't exist or not a regular file
