### PR TITLE
remove lowercasing of engine name to find pychess.py

### DIFF
--- a/lib/pychess/Players/engineNest.py
+++ b/lib/pychess/Players/engineNest.py
@@ -345,7 +345,7 @@ class EngineDiscoverer (GObject.GObject):
     
     def getEngines (self):
         """ Returns list of engine dicts """     
-        return sorted(self.engines, key=lambda engine: engine["name"].lower())
+        return sorted(self.engines, key=lambda engine: engine["name"])
     
     def getEngineN (self, index):
         return self.getEngines()[index]


### PR DESCRIPTION
fixes #1020 

I tested it and it seems to work. The downside to this quick fix is that now the alphabetizing of engines is a little weird and the engines starting with a capital letter (seems to be only ours) appear at the top of the engine selection list. I dont know if this is a major concern.
