### PR TITLE
#1068 minor alteration to whispered text string if player sent it

### DIFF
--- a/sidepanel/chatPanel.py
+++ b/sidepanel/chatPanel.py
@@ -60,7 +60,11 @@ class Sidepanel:
 
     def onMessageSent (self, chatView, text):
         if hasattr(self, "player"):
-            if (text.startswith('# ') or text.startswith('whisper ')):
+            if text.startswith('# ') :
+                text = text[2:]
+                name = self.gamemodel.connection.cm.whisper(text)
+            elif text.startswith('whisper '):
+                text = text[8:]
                 name = self.gamemodel.connection.cm.whisper(text)
             else :
                 self.player.sendMessage(text)


### PR DESCRIPTION
Noticed that if a player sends a whisper then the '#' or 'whisper' at the start of the string was not removed.
