### PR TITLE
test sphinx doc format

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,12 @@ import sys
 import os
 
 # mocking C extension modules we use in pychess
-from unittest.mock import MagicMock
+# Currently looks like unittest.mock is broken in python 3.5
+# had to 'pip install -U mock' to get this to work
+if sys.version_info < (3,5):
+    from unittest.mock import MagicMock
+else:
+    from mock import Mock as MagicMock
 
 class GObjectMock(MagicMock):
     class GObject():

--- a/lib/pychess/widgets/ChatView.py
+++ b/lib/pychess/widgets/ChatView.py
@@ -118,6 +118,15 @@ class ChatView (Gtk.VPaned):
 
     @idle_add
     def update_observers(self, other, observers):
+        """
+        ==================   ============  ============
+        Arguments            Type          Description
+        ==================   ============  ===========
+        other                Not used
+        observers            str           string of observers and there ratings
+        ==================   ============  ===========
+        """
+
         obs_list = observers.split()
         label = _("Observers")
         self.obsView.get_buffer().props.text = ""

--- a/lib/pychess/widgets/ChatView.py
+++ b/lib/pychess/widgets/ChatView.py
@@ -119,12 +119,6 @@ class ChatView (Gtk.VPaned):
     @idle_add
     def update_observers(self, other, observers):
         """
-        ==================   ============  ============
-        Arguments            Type          Description
-        ==================   ============  ===========
-        other                Not used
-        observers            str           string of observers and there ratings
-        ==================   ============  ===========
         """
 
         obs_list = observers.split()

--- a/lib/pychess/widgets/ChatWindow.py
+++ b/lib/pychess/widgets/ChatWindow.py
@@ -565,11 +565,16 @@ class ChannelsPanel (Gtk.ScrolledWindow, Panel):
                     cell.set_property('foreground_rgba',Gdk.RGBA(0,0,0,1))
 
     def channel_Highlight(self, a, channel, b):
-        """ Description: Highlights channels ( that are NOT in focus ) and changes there foreground colour
-        to represent change in contents
-        channel : str - channel the message is intended for
         """
-        
+        :Description: Highlights a channel ( that are **not** in focus ) that has received an update and
+        changes it's foreground colour to represent change in contents
+
+        :param a: not used
+        :param channel: **(str)** The channel the message is intended for
+        :param b:  not used
+        :return: None
+        """
+
         jList = self.joinedList
         lc = jList.leftcol      # treeViewColumn
 


### PR DESCRIPTION
Just a format test, Method of interest is the ChatWindow.py / channel_Hightlight()

Looking for comments on if this is the way we should do the docs for methods going forward.

Also wanted to see finished article on readthedocs as my local copy is still in the old/default format 
