### PR TITLE
#docs test3

### DIFF
--- a/docs/links_names.txt
+++ b/docs/links_names.txt
@@ -1,0 +1,2 @@
+.. _Gtk.TreeViewColumn: http://lazka.github.io/pgi-docs/#Gtk-3.0/classes/TreeViewColumn.html#Gtk.TreeViewColumn 
+.. _Gtk.CellRenderer: http://lazka.github.io/pgi-docs/#Gtk-3.0/classes/CellRenderer.html#Gtk.CellRenderer

--- a/docs/pychess.widgets.rst
+++ b/docs/pychess.widgets.rst
@@ -259,3 +259,5 @@ Module contents
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. include:: ./links_names.txt

--- a/lib/pychess/widgets/ChatWindow.py
+++ b/lib/pychess/widgets/ChatWindow.py
@@ -561,8 +561,8 @@ class ChannelsPanel (Gtk.ScrolledWindow, Panel):
         :Description: Changes the foreground colour  of a  cell
 
 
-        :param lc:  (`TreeViewColumn <http://lazka.github.io/pgi-docs/#Gtk-3.0/classes/TreeViewColumn.html#Gtk.TreeViewColumn>`_ ) The column we are interested in
-        :param cell: **(listcoloumn cell)** The cell we want to change
+        :param lc:  ( Gtk.TreeViewColumn_ ) The column we are interested in
+        :param cell: ( Gtk.CellRenderer_ ) The cell we want to change
         :param model: **(treeview model)**
         :param iter: **(treeview Iterator)**
         :param data: **(Dictionary(key=int,value=bool))**  value is true if channel already highlighted


### PR DESCRIPTION
So using this as a guide

http://nipy.org/nipy/devel/guidelines/sphinx_helpers.html

I got the external gtk links to work, this method does not seem to use intersphinx_mappings ( which I could not get to work at all )

its a simple idea of building a reference doc containing all external links and then pulling the link_names.txt into our rst file we can then simply reference them in the code base ChatWindow.py being an example.

I can build a web crawler that can auto generate this links_names.txt file ( should not take that long to write.

What do you think ?
