### PR TITLE
#1124 Groups separated, ADMIN still to do

### DIFF
--- a/lib/pychess/widgets/ChatView.py
+++ b/lib/pychess/widgets/ChatView.py
@@ -138,7 +138,7 @@ class ChatView (Gtk.VPaned):
             if player.endswith("(U)"):
                 tb.insert(iter, "%s " % player[:-3])
             elif "(" in player:
-                pref,rest = player.split('(')
+                pref,rest = player.split('(',1)
                 self._ensureColor(pref)
                 tb.insert_with_tags_by_name(iter, "%s " % player, pref+"_bold")
             else:


### PR DESCRIPTION
Have to work out what identifies an ADMIN, but the rest of the groups seem to be ok.

Its seems to have resolved the massive jumping about of the list but there is another issue regarding selecting any player from a list that is greater then the vertical aspect of the chat panel window. the list jumps when trying to select a name ( I guess trying to centralize ) but thats another I will raise a ticket for it
