### PR TITLE
Atomic Chess bug

### DIFF
--- a/lib/pychess/Utils/lutils/LBoard.py
+++ b/lib/pychess/Utils/lutils/LBoard.py
@@ -384,6 +384,8 @@ class LBoard(object):
         elif self.variant == ATOMICCHESS:
             if not self.boards[self.color][KING]:
                 return False
+            if -2 < (self.kings[0] >> 3) - (self.kings[1] >> 3) < 2 and -2 < (self.kings[0] & 7) - (self.kings[1] & 7) < 2:
+                return False
         elif self.variant == SITTUYINCHESS and self.plyCount < 16:
             return False
         if self.checked is None:
@@ -399,6 +401,8 @@ class LBoard(object):
             return False
         elif self.variant == ATOMICCHESS:
             if not self.boards[1 - self.color][KING]:
+                return False
+            if -2 < (self.kings[0] >> 3) - (self.kings[1] >> 3) < 2 and -2 < (self.kings[0] & 7) - (self.kings[1] & 7) < 2:
                 return False
         elif self.variant == SITTUYINCHESS and self.plyCount < 16:
             return False


### PR DESCRIPTION
Pychess has a bug where it incorrectly finds moves illegal where you
move the king next to the other king (and the field is attacked) in
atomic chess. According to the [FICS rules](http://www.freechess.org/Help/HelpFiles/atomic.html):

```
 4. You are not allowed to make a move that causes your king to explode in
    the process. This effectively means kings cannot capture other pieces and
    it is therefore legal for two kings to touch. When both kings are
    touching it is not possible to capture one king without destroying the
    other. Thus at this point attacks on the king don't exist and the king is
    effectively invincible.
```

Here is a situation: http://i.imgur.com/1nZ1wxt.png, a legal move for
white would be Kg5, as taking the king with Qxg5 would explode blacks
own king, but this is not recognized by pychess.
So here is a fix (it worked for me), it checks if the kings are next
to each other, and if so it returns False on the isChecked functions.
I don't know pychess's code very well, so perhaps there is a better way.
