### PR TITLE
Correct typographical error (sacrifies → sacrifices)

### DIFF
--- a/lang/af/LC_MESSAGES/pychess.po
+++ b/lang/af/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ar/LC_MESSAGES/pychess.po
+++ b/lang/ar/LC_MESSAGES/pychess.po
@@ -3534,7 +3534,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/az/LC_MESSAGES/pychess.po
+++ b/lang/az/LC_MESSAGES/pychess.po
@@ -3527,7 +3527,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/bg/LC_MESSAGES/pychess.po
+++ b/lang/bg/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/bn/LC_MESSAGES/pychess.po
+++ b/lang/bn/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/br/LC_MESSAGES/pychess.po
+++ b/lang/br/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ca/LC_MESSAGES/pychess.po
+++ b/lang/ca/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/cs/LC_MESSAGES/pychess.po
+++ b/lang/cs/LC_MESSAGES/pychess.po
@@ -3534,7 +3534,7 @@ msgstr "bere zpět figurku"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "obětuje figurku"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/da/LC_MESSAGES/pychess.po
+++ b/lang/da/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr "genvinder materiale"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "ofrer materiale"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/de/LC_MESSAGES/pychess.po
+++ b/lang/de/LC_MESSAGES/pychess.po
@@ -3539,7 +3539,7 @@ msgstr "gewinnt Material zurück"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "opfert Material"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/el/LC_MESSAGES/pychess.po
+++ b/lang/el/LC_MESSAGES/pychess.po
@@ -3530,7 +3530,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/en_GB/LC_MESSAGES/pychess.po
+++ b/lang/en_GB/LC_MESSAGES/pychess.po
@@ -3527,8 +3527,8 @@ msgstr "takes back material"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
-msgstr "sacrifies material"
+msgid "sacrifices material"
+msgstr "sacrifices material"
 
 #: lib/pychess/Utils/lutils/strateval.py:177
 msgid "exchanges material"

--- a/lang/es/LC_MESSAGES/pychess.po
+++ b/lang/es/LC_MESSAGES/pychess.po
@@ -3536,7 +3536,7 @@ msgstr "recupera material"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sacrifica material"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/et/LC_MESSAGES/pychess.po
+++ b/lang/et/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr "võidab materjali tagasi"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "ohverdab materjali"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/eu/LC_MESSAGES/pychess.po
+++ b/lang/eu/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/fa/LC_MESSAGES/pychess.po
+++ b/lang/fa/LC_MESSAGES/pychess.po
@@ -3524,7 +3524,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/fi/LC_MESSAGES/pychess.po
+++ b/lang/fi/LC_MESSAGES/pychess.po
@@ -3527,7 +3527,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "uhraa materiaalia"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/fr/LC_MESSAGES/pychess.po
+++ b/lang/fr/LC_MESSAGES/pychess.po
@@ -3535,7 +3535,7 @@ msgstr "reprend une pièce"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sacrifie une pièce"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ga/LC_MESSAGES/pychess.po
+++ b/lang/ga/LC_MESSAGES/pychess.po
@@ -3532,7 +3532,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/gl/LC_MESSAGES/pychess.po
+++ b/lang/gl/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/he/LC_MESSAGES/pychess.po
+++ b/lang/he/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/hi/LC_MESSAGES/pychess.po
+++ b/lang/hi/LC_MESSAGES/pychess.po
@@ -3527,7 +3527,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/hr/LC_MESSAGES/pychess.po
+++ b/lang/hr/LC_MESSAGES/pychess.po
@@ -3534,7 +3534,7 @@ msgstr "uzima nazad materijal"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "žrtvuje materijal"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/hu/LC_MESSAGES/pychess.po
+++ b/lang/hu/LC_MESSAGES/pychess.po
@@ -3528,7 +3528,7 @@ msgstr "visszaveszi az anyagot"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "anyagot veszít"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/id/LC_MESSAGES/pychess.po
+++ b/lang/id/LC_MESSAGES/pychess.po
@@ -3524,7 +3524,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/is/LC_MESSAGES/pychess.po
+++ b/lang/is/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/it/LC_MESSAGES/pychess.po
+++ b/lang/it/LC_MESSAGES/pychess.po
@@ -3534,7 +3534,7 @@ msgstr "si riprende il materiale"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sacrifica materiale"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ja/LC_MESSAGES/pychess.po
+++ b/lang/ja/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/jv/LC_MESSAGES/pychess.po
+++ b/lang/jv/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/kn/LC_MESSAGES/pychess.po
+++ b/lang/kn/LC_MESSAGES/pychess.po
@@ -3525,7 +3525,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ko/LC_MESSAGES/pychess.po
+++ b/lang/ko/LC_MESSAGES/pychess.po
@@ -3524,7 +3524,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ku/LC_MESSAGES/pychess.po
+++ b/lang/ku/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/lt/LC_MESSAGES/pychess.po
+++ b/lang/lt/LC_MESSAGES/pychess.po
@@ -3527,7 +3527,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ml/LC_MESSAGES/pychess.po
+++ b/lang/ml/LC_MESSAGES/pychess.po
@@ -3527,7 +3527,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/nb/LC_MESSAGES/pychess.po
+++ b/lang/nb/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr "vinner tilbake materiell"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "ofrer materiell"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/nl/LC_MESSAGES/pychess.po
+++ b/lang/nl/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr "verovert stukken terug"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "offert stukken op"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/oc/LC_MESSAGES/pychess.po
+++ b/lang/oc/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sacrifica una pèça"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/pl/LC_MESSAGES/pychess.po
+++ b/lang/pl/LC_MESSAGES/pychess.po
@@ -3535,7 +3535,7 @@ msgstr "odbijają materiał"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "poświęcają materiał"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/pl_PL/LC_MESSAGES/pychess.po
+++ b/lang/pl_PL/LC_MESSAGES/pychess.po
@@ -3527,7 +3527,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/pt/LC_MESSAGES/pychess.po
+++ b/lang/pt/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr "recupera material"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sacrifica material"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/pt_BR/LC_MESSAGES/pychess.po
+++ b/lang/pt_BR/LC_MESSAGES/pychess.po
@@ -3534,7 +3534,7 @@ msgstr "recuperam material"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sacrificam peça"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/pychess.pot
+++ b/lang/pychess.pot
@@ -3536,7 +3536,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ro/LC_MESSAGES/pychess.po
+++ b/lang/ro/LC_MESSAGES/pychess.po
@@ -3530,7 +3530,7 @@ msgstr "ia înapoi material"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sacrifică material"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/ru/LC_MESSAGES/pychess.po
+++ b/lang/ru/LC_MESSAGES/pychess.po
@@ -3543,7 +3543,7 @@ msgstr "возвращают материал"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "жертвуют материал"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/si/LC_MESSAGES/pychess.po
+++ b/lang/si/LC_MESSAGES/pychess.po
@@ -3473,7 +3473,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:162
 #: lib/pychess/Utils/lutils/strateval.py:170
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:164

--- a/lang/sk/LC_MESSAGES/pychess.po
+++ b/lang/sk/LC_MESSAGES/pychess.po
@@ -3530,7 +3530,7 @@ msgstr "vezme späť materiál"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "obetuje materiál"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/sl/LC_MESSAGES/pychess.po
+++ b/lang/sl/LC_MESSAGES/pychess.po
@@ -3531,7 +3531,7 @@ msgstr "povrne material"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "žrtvuje material"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/sq/LC_MESSAGES/pychess.po
+++ b/lang/sq/LC_MESSAGES/pychess.po
@@ -3527,7 +3527,7 @@ msgstr "merr prapa materialin"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "sakrifikon materialin"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/sv/LC_MESSAGES/pychess.po
+++ b/lang/sv/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/te/LC_MESSAGES/pychess.po
+++ b/lang/te/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/tr/LC_MESSAGES/pychess.po
+++ b/lang/tr/LC_MESSAGES/pychess.po
@@ -3533,7 +3533,7 @@ msgstr "kaybedilen materyalı geri alır"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "taşı feda eder"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/uk/LC_MESSAGES/pychess.po
+++ b/lang/uk/LC_MESSAGES/pychess.po
@@ -3528,7 +3528,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/vi/LC_MESSAGES/pychess.po
+++ b/lang/vi/LC_MESSAGES/pychess.po
@@ -3524,7 +3524,7 @@ msgstr "gỡ lại quân"
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr "thí quân"
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/wa/LC_MESSAGES/pychess.po
+++ b/lang/wa/LC_MESSAGES/pychess.po
@@ -3473,7 +3473,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:162
 #: lib/pychess/Utils/lutils/strateval.py:170
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:164

--- a/lang/zh_CN/LC_MESSAGES/pychess.po
+++ b/lang/zh_CN/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lang/zu/LC_MESSAGES/pychess.po
+++ b/lang/zu/LC_MESSAGES/pychess.po
@@ -3526,7 +3526,7 @@ msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:175
 #: lib/pychess/Utils/lutils/strateval.py:183
-msgid "sacrifies material"
+msgid "sacrifices material"
 msgstr ""
 
 #: lib/pychess/Utils/lutils/strateval.py:177

--- a/lib/pychess/Utils/lutils/strateval.py
+++ b/lib/pychess/Utils/lutils/strateval.py
@@ -172,7 +172,7 @@ def attack_type(model, ply, phase):
             else:
                 see = staticExchangeEvaluate(oldboard, move)
                 if see < 0:
-                    yield _("sacrifies material")
+                    yield _("sacrifices material")
                 elif see == 0:
                     yield _("exchanges material")
                 elif see > 0:
@@ -180,7 +180,7 @@ def attack_type(model, ply, phase):
     else:
         see = staticExchangeEvaluate(oldboard, move)
         if see < 0:
-            yield _("sacrifies material")
+            yield _("sacrifices material")
 
     PIECE_VALUES[BISHOP] = bishopBackup
 


### PR DESCRIPTION
This commit changes instances of the word "sacrifies" to the more common word "sacrifices".
The former isn't in most dictionaries, but apparently used to be a word in Middle English.

Updated the message ID too.
