### PR TITLE
Fix game properties round bug on local game

### DIFF
--- a/lib/pychess/widgets/gameinfoDialog.py
+++ b/lib/pychess/widgets/gameinfoDialog.py
@@ -8,7 +8,7 @@ def run(widgets):
     gamemodel = gamewidget.cur_gmwidg().gamemodel
     widgets["event_entry"].set_text(gamemodel.tags["Event"])
     widgets["site_entry"].set_text(gamemodel.tags["Site"])
-    widgets["round_entry"].set_text(gamemodel.tags["Round"])
+    widgets["round_entry"].set_text(str(gamemodel.tags["Round"]))
     widgets["white_entry"].set_text(gamemodel.tags["White"])
     widgets["black_entry"].set_text(gamemodel.tags["Black"])
 


### PR DESCRIPTION
Previously when playing a local game and using File -> game properties I would encounter the error : 
```
Traceback (most recent call last):
  File "/home/boris/Documents/play/chess/pychess/lib/pychess/Main.py", line 228, in on_properties1_activate
    gameinfoDialog.run(gamewidget.getWidgets())
  File "/home/boris/Documents/play/chess/pychess/lib/pychess/widgets/gameinfoDialog.py", line 11, in run
    widgets["round_entry"].set_text(gamemodel.tags["Round"])
TypeError: Must be string, not int
```
This PR fixes this issue.