### PR TITLE
Minimal limit for MultiPV in panel Hints

### DIFF
--- a/lib/pychess/Players/CECPEngine.py
+++ b/lib/pychess/Players/CECPEngine.py
@@ -960,6 +960,9 @@ class CECPEngine(ProtocolEngine):
     def getAnalysisLines(self):
         return 1
 
+    def minAnalysisLines(self):
+        return 1
+
     def maxAnalysisLines(self):
         return 1
 

--- a/lib/pychess/Players/Engine.py
+++ b/lib/pychess/Players/Engine.py
@@ -79,6 +79,9 @@ class Engine(Player):
     def canAnalyze(self):
         raise NotImplementedError
 
+    def minAnalysisLines(self):
+        raise NotImplementedError
+
     def maxAnalysisLines(self):
         raise NotImplementedError
 

--- a/lib/pychess/Players/UCIEngine.py
+++ b/lib/pychess/Players/UCIEngine.py
@@ -675,6 +675,12 @@ class UCIEngine(ProtocolEngine):
         except (KeyError, ValueError):
             return 1  # Engine does not support the MultiPV option
 
+    def minAnalysisLines(self):
+        try:
+            return int(self.options["MultiPV"]["min"])
+        except (KeyError, ValueError):
+            return 1  # Engine does not support the MultiPV option
+
     def maxAnalysisLines(self):
         try:
             return int(self.options["MultiPV"]["max"])
@@ -682,16 +688,14 @@ class UCIEngine(ProtocolEngine):
             return 1  # Engine does not support the MultiPV option
 
     def requestMultiPV(self, n):
-        multipvMax = self.maxAnalysisLines()
-        n = min(n, multipvMax)
-
+        n = min(n, self.maxAnalysisLines())
+        n = max(n, self.minAnalysisLines())
         if n != self.multipvSetting:
             conf.set("multipv", n)
             self.multipvSetting = n
             print("stop", file=self.engine)
             print("setoption name MultiPV value", n, file=self.engine)
             self._searchNow()
-
         return n
 
     def __repr__(self):

--- a/lib/pychess/perspectives/games/bookPanel.py
+++ b/lib/pychess/perspectives/games/bookPanel.py
@@ -285,11 +285,8 @@ class EngineAdvisor(Advisor):
             self.boardview.model.pause_analyzer(self.mode)
 
     def multipv_edited(self, value):
-        if value > self.engine.maxAnalysisLines():
-            return
-
+        value = self.engine.requestMultiPV(value)
         if value != self.linesExpected:
-            self.engine.requestMultiPV(value)
             parent = self.store.get_iter(self.path)
             if value > self.linesExpected:
                 while self.linesExpected < value:
@@ -302,6 +299,7 @@ class EngineAdvisor(Advisor):
                     if child is not None:
                         self.store.remove(child)
                     self.linesExpected -= 1
+        return value
 
     def row_activated(self, iter, model):
         if not self.active:
@@ -489,8 +487,7 @@ class Sidepanel(object):
 
         def multipv_edited(renderer, path, text):
             iter = self.store.get_iter(path)
-            self.store.set_value(iter, 2, int(text))
-            self.advisors[int(path[0])].multipv_edited(int(text))
+            self.store.set_value(iter, 2, self.advisors[int(path[0])].multipv_edited(int(text)))
 
         self.multipv_cid = self.multipvRenderer.connect('edited', multipv_edited)
 


### PR DESCRIPTION
Hello,

In the panel Hints, you can force (without using +/-) a null or negative value for MultiPV. This check ensures that it cannot happen.

Also, if you set a zero, you cannot restore the value for the current game. That's a concern with the UI, or maybe a choice by design.

Regards.