### PR TITLE
No blank tag ECO

### DIFF
--- a/lib/pychess/Savers/pgn.py
+++ b/lib/pychess/Savers/pgn.py
@@ -138,7 +138,7 @@ def save(handle, model, position=None):
     print('[White "%s"]' % repr(model.players[WHITE]), file=handle)
     print('[Black "%s"]' % repr(model.players[BLACK]), file=handle)
     print('[Result "%s"]' % status, file=handle)
-    if "ECO" in model.tags:
+    if ("ECO" in model.tags) and (model.tags["ECO"] != ''):
         print('[ECO "%s"]' % model.tags["ECO"], file=handle)
     if "WhiteElo" in model.tags:
         print('[WhiteElo "%s"]' % model.tags["WhiteElo"], file=handle)


### PR DESCRIPTION
Hello,

If you start a game from a position and export it to PGN, you may have a blank ECO tag in the output file :

```
(Pdb) print(model)
<GameModel at 3017881876 (ply=2, move=e5f3, variant=b'Normal', status=2, reason=39,
players=[Me, You], tags={'Month': 10, 'Time': '23:38:00', 'Black': 'You',
'Event': 'Local Event', 'White': 'Me', 'ECO': '', 'Opening': '', 'Site': 'Local Site',
'Variation': '', 'Result': '*', 'Round': 1, 'Year': 2017, 'Day': 15}
```

This PR avoids that.

Regards