### PR TITLE
Don't load the incorrect engines

### DIFF
--- a/lib/pychess/widgets/enginesDialog.py
+++ b/lib/pychess/widgets/enginesDialog.py
@@ -284,26 +284,27 @@ class EnginesDialog():
                                 break
                             else:
                                 continue
-                            if not check_ok:
-                                # restore the original
-                                engine = discoverer.getEngineByName(
-                                    self.cur_engine)
-                                engine_chooser_dialog.set_filename(engine[
-                                    "command"])
-                                msg_dia = Gtk.MessageDialog(mainwindow(),
-                                                            type=Gtk.MessageType.ERROR,
-                                                            buttons=Gtk.ButtonsType.OK)
-                                msg_dia.set_markup(
-                                    _("<big><b>Unable to add %s</b></big>" %
-                                      new_engine))
-                                msg_dia.format_secondary_text(_(
-                                    "There is something wrong with this executable"))
-                                msg_dia.run()
-                                msg_dia.hide()
-                                engine_chooser_dialog.hide()
-                                self.add = False
-                                engine_chooser_dialog.hide()
-                                return
+
+                        if not check_ok:
+                            # restore the original
+                            engine = discoverer.getEngineByName(
+                                self.cur_engine)
+                            engine_chooser_dialog.set_filename(engine[
+                                "command"])
+                            msg_dia = Gtk.MessageDialog(mainwindow(),
+                                                        type=Gtk.MessageType.ERROR,
+                                                        buttons=Gtk.ButtonsType.OK)
+                            msg_dia.set_markup(
+                                _("<big><b>Unable to add %s</b></big>" %
+                                  new_engine))
+                            msg_dia.format_secondary_text(_(
+                                "There is something wrong with this executable"))
+                            msg_dia.run()
+                            msg_dia.hide()
+                            engine_chooser_dialog.hide()
+                            self.add = False
+                            engine_chooser_dialog.hide()
+                            return
 
                         binname = os.path.split(new_engine)[1]
                         for eng in discoverer.getEngines():


### PR DESCRIPTION
Hello,

When you add an incorrect engine, the error popup is not shown. It also generates an incorrect entry in `engines.json` which cannot be removed from the UI :

```
,
 {
  "command": "/home/komodo-9.02-linux",
  "country": "unknown",
  "md5": "ca1d3b4018540ee0c9a3c66cae5c1229",
  "name": "komodo-9.02-linux",
  "protocol": "xboard",
  "recheck": true
 }
```

It looks like a problem in the indent of the existing code. Here the fix which provides the expected output to the player.

Regards