### PR TITLE
No selection of the unknown country

### DIFF
--- a/lib/pychess/widgets/enginesDialog.py
+++ b/lib/pychess/widgets/enginesDialog.py
@@ -467,8 +467,8 @@ class EnginesDialog():
         def country_keypressed(widget, event):
             idx = 0
             for iso in ISO3166_LIST:
-                if (ord(iso.country[0].lower()) == event.keyval) or \
-                   (ord(iso.country[0].upper()) == event.keyval):
+                if (idx != 0) and ((ord(iso.country[0].lower()) == event.keyval) or
+                                   (ord(iso.country[0].upper()) == event.keyval)):
                     widget.set_active(idx)
                     break
                 idx += 1


### PR DESCRIPTION
Little correction for 9c72933dfeae00ba95e4b40ed92520921a1c108e.
"Unknown" should not be fetched if I press "U" in English (Uganda) or "I" in French (Iceland).
Unknown is voluntarily the first unsorted item of the list of the countries, so we don't loop on it.