### PR TITLE
Refresh engineDialog with 1 engine only

### DIFF
--- a/lib/pychess/widgets/enginesDialog.py
+++ b/lib/pychess/widgets/enginesDialog.py
@@ -525,6 +525,7 @@ class EnginesDialog():
         tree_selection = self.tv.get_selection()
         tree_selection.connect('changed', selection_changed)
         tree_selection.select_path((0, ))
+        selection_changed(tree_selection)
 
 
 class KeyValueCellRenderer(Gtk.CellRenderer):


### PR DESCRIPTION
There is no change event in engineDialog if `engines.json` has 1 entry only.
The window appears as if there was no setting for the selected engine.
It affects both Windows and Linux.