### PR TITLE
Processing PGN blank tags

### DIFF
--- a/lib/pychess/Database/PgnImport.py
+++ b/lib/pychess/Database/PgnImport.py
@@ -266,7 +266,11 @@ class PgnImport():
                         black = tags["Variation"] if "Variation" in tags else ""
                     else:
                         white = tags["White"] if "White" in tags else ""
+                        if white == "":
+                            white = "?"
                         black = tags["Black"] if "Black" in tags else ""
+                        if black == "":
+                            black = "?"
 
                     event_id = get_id(tags["Event"] if "Event" in tags else "", event, EVENT)
 

--- a/lib/pychess/Savers/pgn.py
+++ b/lib/pychess/Savers/pgn.py
@@ -641,12 +641,12 @@ class PGNFile(ChessFile):
             variant = self.get_variant(rec)
 
         # the seven mandatory PGN headers
-        model.tags['Event'] = rec["Event"]
-        model.tags['Site'] = rec["Site"]
+        model.tags['Event'] = rec["Event"] if rec["Event"] is not None else ""
+        model.tags['Site'] = rec["Site"] if rec["Site"] is not None else ""
         model.tags['Date'] = game_date
         model.tags['Round'] = rec["Round"]
-        model.tags['White'] = rec["White"]
-        model.tags['Black'] = rec["Black"]
+        model.tags['White'] = rec["White"] if rec["White"] is not None else "?"
+        model.tags['Black'] = rec["Black"] if rec["Black"] is not None else "?"
         model.tags['Result'] = result
 
         if model.tags['Date']:


### PR DESCRIPTION
**1)** If you have a blank tag for `Event` or `Site`, you can load the PGN file but you can't access to its properties (menu Game>Properties). The event and site use an internal identifier which may cause the value to be equal to *None* and this value cannot be passed to a textbox.

```
Traceback (most recent call last):
  File "/home/pychess/lib/pychess/Main.py", line 239, in on_properties1_activate
    gameinfoDialog.run(gamewidget.getWidgets())
  File "/home/pychess/lib/pychess/widgets/gameinfoDialog.py", line 10, in run
    widgets["event_entry"].set_text(gamemodel.tags["Event"])
TypeError: Argument 1 does not allow None as a value
```

**2)** If the tags `White` and `Black` are blank, the game is moved to the database, but after opening it, you see nothing of the game. The proposal is to assign "?".

These two effects were seen during the processing of that file which was originally not so blank :

```
[Event ""]
[Site ""]
[Date "2017.??.??"]
[EventDate "?"]
[Round ""]
[Result "0-1"]
[White ""]
[Black ""]
[ECO ""]
[Opening ""]
[WhiteElo "?"]
[BlackElo "1450"]
[PlyCount ""]

1. d4 d5
```