### PR TITLE
No override of the deeper scores

### DIFF
--- a/lib/pychess/Utils/GameModel.py
+++ b/lib/pychess/Utils/GameModel.py
@@ -284,10 +284,12 @@ class GameModel(GObject.GObject):
             ply = analyzer.board.ply
             if score is not None:
                 if analyzer.mode == ANALYZING:
-                    self.scores[ply] = (pv, score, depth)
-                    self.emit("analysis_changed", ply)
+                    if (ply not in self.scores) or (self.scores[ply][2] <= depth):
+                        self.scores[ply] = (pv, score, depth)
+                        self.emit("analysis_changed", ply)
                 else:
-                    self.spy_scores[ply] = (pv, score, depth)
+                    if (ply not in self.spy_scores) or (self.spy_scores[ply][2] <= depth):
+                        self.spy_scores[ply] = (pv, score, depth)
 
     def setOpening(self, ply=None):
         if ply is None:


### PR DESCRIPTION
Hello,

It doesn't make sense to save the score without checking if the existing one has been computed deeper.
If you analyzed your game, now if you browse your game, you will not lose what was calculated.
It gives then a more consistent graph of the scores.

I also noticed that changing the position in the annotation panel should reset the current analysis in memory in order that it doesn't get copied from the previous move. May I ask you to verify that point ?

Regards