### PR TITLE
No override of the deep scores v2

### DIFF
--- a/lib/pychess/Utils/GameModel.py
+++ b/lib/pychess/Utils/GameModel.py
@@ -284,11 +284,11 @@ class GameModel(GObject.GObject):
             ply = analyzer.board.ply
             if score is not None:
                 if analyzer.mode == ANALYZING:
-                    if (ply not in self.scores) or (self.scores[ply][2] <= depth):
+                    if (ply not in self.scores) or (int(self.scores[ply][2]) <= int(depth)):
                         self.scores[ply] = (pv, score, depth)
                         self.emit("analysis_changed", ply)
                 else:
-                    if (ply not in self.spy_scores) or (self.spy_scores[ply][2] <= depth):
+                    if (ply not in self.spy_scores) or (int(self.spy_scores[ply][2]) <= int(depth)):
                         self.spy_scores[ply] = (pv, score, depth)
 
     def setOpening(self, ply=None):

--- a/lib/pychess/perspectives/games/annotationPanel.py
+++ b/lib/pychess/perspectives/games/annotationPanel.py
@@ -355,6 +355,10 @@ class Sidepanel:
                 menuitem.connect('activate', self.remove_symbols, board)
                 self.menu.append(menuitem)
 
+                menuitem = Gtk.MenuItem(_("Reset the evaluations"))
+                menuitem.connect('activate', self.reset_evaluations)
+                self.menu.append(menuitem)
+
                 self.menu.show_all()
                 self.menu.popup(None, None, None, None, event.button,
                                 event.time)
@@ -444,6 +448,10 @@ class Sidepanel:
             board.nags = []
             self.update_node(board)
             self.gamemodel.needsSave = True
+
+    def reset_evaluations(self, widget):
+        self.gamemodel.scores = {}
+        self.update()
 
     def print_node(self, node):
         """ Just a debug helper """
@@ -577,7 +585,7 @@ class Sidepanel:
         return iter.get_offset() - start
 
     def update_node(self, board):
-        """ Called after adding/removing evaluation simbols """
+        """ Called after adding/removing evaluation symbols """
         node = None
         for n in self.nodelist:
             if n["board"] == board:


### PR DESCRIPTION
Hello,

Initially, this PR aims to add a popup menu item to reset all the existing evaluations, because if you relaunch the analysis with another analyzer, it will not necessarily override the existing evaluations. It looks OK.

However, the PR also fixes a regression I didn't noticed : after #1495, the analysis is stucked at depth 9 because pyChess returns the parsed depth as... a string (not an integer). So the added comparison was not fully effective. The problem mentioned in the previous PR is now fully reproducible :
- Play several moves
- Go back to the first move, and leave some time for the analysis to run as deep as possible
- Go to the next move (and so on) : it receives the residual evaluation of the previous position because this is based on the events and no link is made with the original node

I don't know how to fix that. That problem was not so obvious with the first version of the PR, that's why I am a bit disappointed at that situation (incomplete code).

Regards