### PR TITLE
Elo rating change in UI and PGN

### DIFF
--- a/glade/PyChess.glade
+++ b/glade/PyChess.glade
@@ -1055,10 +1055,13 @@
                           <object class="GtkTable" id="table1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="n_rows">5</property>
+                            <property name="n_rows">6</property>
                             <property name="n_columns">4</property>
                             <property name="column_spacing">6</property>
                             <property name="row_spacing">4</property>
+                            <child>
+                              <placeholder/>
+                            </child>
                             <child>
                               <object class="GtkEntry" id="event_entry">
                                 <property name="visible">True</property>
@@ -1206,6 +1209,7 @@
                               <object class="GtkLabel" id="label60">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
                                 <property name="label" translatable="yes">White ELO:</property>
                               </object>
                               <packing>
@@ -1217,6 +1221,7 @@
                               <object class="GtkLabel" id="label61">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Black ELO:</property>
                               </object>
                               <packing>
@@ -1254,11 +1259,12 @@
                               <object class="GtkLabel" id="label66">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Annotator:</property>
                               </object>
                               <packing>
-                                <property name="top_attach">4</property>
-                                <property name="bottom_attach">5</property>
+                                <property name="top_attach">5</property>
+                                <property name="bottom_attach">6</property>
                               </packing>
                             </child>
                             <child>
@@ -1268,6 +1274,46 @@
                               </object>
                               <packing>
                                 <property name="left_attach">1</property>
+                                <property name="right_attach">4</property>
+                                <property name="top_attach">5</property>
+                                <property name="bottom_attach">6</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label67">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">Rating change:</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">4</property>
+                                <property name="bottom_attach">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="w_elo_change">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">For each player, the statistics provide the probability to win the game and the variation of your ELO if you lose / end into a tie / win, or simply the final ELO rating change</property>
+                                <property name="label" translatable="yes">-</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="top_attach">4</property>
+                                <property name="bottom_attach">5</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="b_elo_change">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="tooltip_text" translatable="yes">For each player, the statistics provide the probability to win the game and the variation of your ELO if you lose / end into a tie / win, or simply the final ELO rating change</property>
+                                <property name="label" translatable="yes">-</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">3</property>
                                 <property name="right_attach">4</property>
                                 <property name="top_attach">4</property>
                                 <property name="bottom_attach">5</property>
@@ -2233,7 +2279,7 @@ It will search positions from http://www.k4it.de/</property>
                                                 <property name="label" translatable="yes">The inverse analyzer will analyze the game as if your opponent was to move. &lt;b&gt;This is necessary for the spy mode to work&lt;/b&gt;</property>
                                                 <property name="use_markup">True</property>
                                                 <property name="wrap">True</property>
-                                                <property name="xalign">3.7252902984619141e-09</property>
+                                                <property name="xalign">0</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -3866,7 +3912,7 @@ It will search positions from http://www.k4it.de/</property>
                                 <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">Use name format:</property>
                                 <property name="xalign">0</property>
-                                <property name="yalign">0.49000000953674316</property>
+                                <property name="yalign">0.5</property>
                               </object>
                               <packing>
                                 <property name="left_attach">0</property>

--- a/lib/pychess/Utils/GameModel.py
+++ b/lib/pychess/Utils/GameModel.py
@@ -226,6 +226,19 @@ class GameModel(GObject.GObject):
         log.debug("GameModel.setPlayers: <- emit players_changed")
         log.debug("GameModel.setPlayers: returning")
 
+    def getTag(self, name, defaultValue):
+        if name in self.tags and self.tags[name] is not None:
+            return self.tags[name]
+        else:
+            return defaultValue
+
+    def getTagExport(self, name, defaultValue):
+        val = self.getTag(name, defaultValue)
+        if type(val) is str:
+            val = val.replace("\\", "\\\\")
+            val = val.replace("\"", "\\\"")
+        return val
+
     def color(self, player):
         if player is self.players[0]:
             return WHITE
@@ -299,7 +312,7 @@ class GameModel(GObject.GObject):
         if ply > 0:
             opening = get_eco(self.getBoardAtPly(ply).board.hash)
         else:
-            opening = ("", "", "")
+            opening = None
         if opening is not None:
             self.tags["ECO"] = opening[0]
             self.tags["Opening"] = opening[1]

--- a/lib/pychess/Utils/TimeModel.py
+++ b/lib/pychess/Utils/TimeModel.py
@@ -99,9 +99,9 @@ class TimeModel(GObject.GObject):
             return False
         return True
 
-        ############################################################################
-        # Interacting                                                              #
-        ############################################################################
+    ############################################################################
+    # Interacting                                                              #
+    ############################################################################
 
     def setMovingColor(self, movingColor):
         self.movingColor = movingColor
@@ -261,3 +261,7 @@ class TimeModel(GObject.GObject):
     def hasBWTimes(self, bmovecount, wmovecount):
         return len(self.intervals[BLACK]) > bmovecount and len(self.intervals[
             WHITE]) > wmovecount
+
+    def isBlitzFide(self):
+        val = 60 * self.minutes + 60 * (self.gain if self.handle_gain else 0)
+        return 300 <= val and val <= 600  # Between 5 and 10 minutes for 60 moves (estimation)

--- a/lib/pychess/Utils/elo.py
+++ b/lib/pychess/Utils/elo.py
@@ -1,0 +1,135 @@
+from pychess.Utils.const import WHITE, WHITEWON, BLACK, BLACKWON, DRAW
+
+
+def get_elo_rating_change(model, overridden_welo, overridden_belo):
+
+# http://www.fide.com/fide/handbook.html?id=197&view=article (§8.5, July 2017)
+
+    def individual_elo_change(elo_player, elo_opponent, blitz):
+        result = {}
+
+        # Adaptation of the inbound parameters
+        pprov = '?' in elo_player
+        try:
+            pval = int(elo_player.replace("?", ""))
+        except:
+            pval = 0
+        try:
+            oval = int(elo_opponent.replace("?", ""))
+        except:
+            oval = 0
+        if pval == 0 or oval == 0:
+            return None
+
+        # Development coefficient - We ignore the age of the player and we assume that
+        # he is already rated. The provisional flag '?' just denotes that he has not
+        # played his first 30 games, but it may also denotes that he never had any
+        # ranking. The calculation being based on the current game only, we can't
+        # handle that second specific case
+        if blitz:
+            k = 20
+        else:
+            if pprov:
+                k = 40
+            else:
+                if pval >= 2400:
+                    k = 10
+                else:
+                    k = 20
+
+        # Probability of gain
+        d = pval - oval
+        d = max(-400, d)
+        d = min(400, d)
+        # The approximate formula should not be used : result["pd"] = 1.0/(1+10**(-d/400))
+        pd = [50, 50, 50, 50, 51, 51, 51, 51, 51, 51, 51, 52, 52, 52, 52, 52, 52, 52, 53, 53,
+              53, 53, 53, 53, 53, 53, 54, 54, 54, 54, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55,
+              56, 56, 56, 56, 56, 56, 56, 57, 57, 57, 57, 57, 57, 57, 58, 58, 58, 58, 58, 58,
+              58, 58, 59, 59, 59, 59, 59, 59, 59, 60, 60, 60, 60, 60, 60, 60, 60, 61, 61, 61,
+              61, 61, 61, 61, 62, 62, 62, 62, 62, 62, 62, 62, 63, 63, 63, 63, 63, 63, 63, 64,
+              64, 64, 64, 64, 64, 64, 64, 65, 65, 65, 65, 65, 65, 65, 66, 66, 66, 66, 66, 66,
+              66, 66, 67, 67, 67, 67, 67, 67, 67, 67, 68, 68, 68, 68, 68, 68, 68, 68, 69, 69,
+              69, 69, 69, 69, 69, 69, 70, 70, 70, 70, 70, 70, 70, 70, 71, 71, 71, 71, 71, 71,
+              71, 71, 71, 72, 72, 72, 72, 72, 72, 72, 72, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+              74, 74, 74, 74, 74, 74, 74, 74, 74, 75, 75, 75, 75, 75, 75, 75, 75, 75, 76, 76,
+              76, 76, 76, 76, 76, 76, 76, 77, 77, 77, 77, 77, 77, 77, 77, 77, 78, 78, 78, 78,
+              78, 78, 78, 78, 78, 78, 79, 79, 79, 79, 79, 79, 79, 79, 79, 79, 80, 80, 80, 80,
+              80, 80, 80, 80, 80, 80, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 81, 82, 82, 82,
+              82, 82, 82, 82, 82, 82, 82, 82, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 83, 84,
+              84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 84, 85, 85, 85, 85, 85, 85, 85, 85, 85,
+              85, 85, 85, 86, 86, 86, 86, 86, 86, 86, 86, 86, 86, 86, 86, 86, 87, 87, 87, 87,
+              87, 87, 87, 87, 87, 87, 87, 87, 87, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88, 88,
+              88, 88, 88, 88, 88, 89, 89, 89, 89, 89, 89, 89, 89, 89, 89, 89, 89, 89, 90, 90,
+              90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 90, 91, 91, 91, 91, 91,
+              91, 91, 91, 91, 91, 91, 91, 91, 91, 91, 91, 91, 92, 92, 92, 92, 92, 92, 92, 92,
+              92][abs(d)] / 100.0
+        result["pd"] = pd if pval >= oval else 1.0 - pd
+
+        # New difference in Elo for loss, draw, win
+        for score in [0, 1, 2]:
+            result["diff%d" % score] = round(k * ([0, 0.5, 1][score] - result["pd"]), 1)
+
+        # Result
+        return result
+
+    # Gathering of the data
+    welo = model.getTag("WhiteElo", "") if overridden_welo is None else overridden_welo
+    belo = model.getTag("BlackElo", "") if overridden_belo is None else overridden_belo
+    blitz = model.timemodel.isBlitzFide()
+
+    # Result
+    result = [None, None]
+    result[WHITE] = individual_elo_change(welo, belo, blitz)
+    result[BLACK] = individual_elo_change(belo, welo, blitz)
+    return None if result[WHITE] is None or result[BLACK] is None else result
+
+
+def get_elo_rating_change_str(model, player, overridden_welo, overridden_belo):
+    # Determination of the ELO rating change
+    erc = get_elo_rating_change(model, overridden_welo, overridden_belo)
+    if erc is None:
+        return "-"
+    erc = erc[player]
+
+    # Status of the game
+    if (model.status == WHITEWON and player == WHITE) or (model.status == BLACKWON and player == BLACK):
+        d = 2
+    else:
+        if (model.status == WHITEWON and player == BLACK) or (model.status == BLACKWON and player == WHITE):
+            d = 0
+        else:
+            if model.status == DRAW:
+                d = 1
+            else:
+                return "%.0f%%, %.1f / %.1f / %.1f" % (100 * erc["pd"], erc["diff0"], erc["diff1"], erc["diff2"])
+
+    # Result
+    return "%s%.1f" % ("+" if erc["diff%d" % d] > 0 else "", erc["diff%d" % d])
+
+
+def get_elo_rating_change_pgn(model, player):
+    # One move must occur to validate the rating
+    if model.ply == 0:
+        return ""
+
+    # Retrieval of the statistics for the player
+    data = get_elo_rating_change(model, None, None)
+    if data is None:
+        return ""
+    data = data[player]
+
+    # Status of the game
+    if (model.status == WHITEWON and player == WHITE) or (model.status == BLACKWON and player == BLACK):
+        d = 2
+    else:
+        if (model.status == WHITEWON and player == BLACK) or (model.status == BLACKWON and player == WHITE):
+            d = 0
+        else:
+            if model.status == DRAW:
+                d = 1
+            else:
+                return ""
+
+    # Result is rounded to the nearest integer
+    r = int(round(data["diff%s" % d], 0))
+    return "+%d" % r if r > 0 else str(r)

--- a/lib/pychess/widgets/gameinfoDialog.py
+++ b/lib/pychess/widgets/gameinfoDialog.py
@@ -1,5 +1,6 @@
 from pychess.Utils.const import BLACK, WHITE
 from pychess.perspectives import perspective_manager
+from pychess.Utils.elo import get_elo_rating_change_str
 
 firstRun = True
 
@@ -8,17 +9,15 @@ def run(widgets):
     persp = perspective_manager.get_perspective("games")
     gamemodel = persp.cur_gmwidg().gamemodel
 
-    def set_field_value(name, tag):
-        widgets[name].set_text(str(gamemodel.tags[tag] if tag in gamemodel.tags else ""))
-
-    set_field_value("event_entry", "Event")
-    set_field_value("site_entry", "Site")
-    set_field_value("round_entry", "Round")
-    set_field_value("white_entry", "White")
-    set_field_value("black_entry", "Black")
-    set_field_value("white_elo_entry", "WhiteElo")
-    set_field_value("black_elo_entry", "BlackElo")
-    set_field_value("annotator_entry", "Annotator")
+    widgets["event_entry"].set_text(str(gamemodel.getTag("Event", "")))
+    widgets["site_entry"].set_text(str(gamemodel.getTag("Site", "")))
+    widgets["round_entry"].set_text(str(gamemodel.getTag("Round", "")))
+    widgets["white_entry"].set_text(str(gamemodel.getTag("White", "")))
+    widgets["black_entry"].set_text(str(gamemodel.getTag("Black", "")))
+    widgets["white_elo_entry"].set_text(str(gamemodel.getTag("WhiteElo", "")))
+    widgets["black_elo_entry"].set_text(str(gamemodel.getTag("BlackElo", "")))
+    refresh_elo_rating_change(widgets)
+    widgets["annotator_entry"].set_text(str(gamemodel.getTag("Annotator", "")))
 
     # Notice: GtkCalender month goes from 0 to 11, but gamemodel goes from
     # 1 to 12
@@ -61,6 +60,18 @@ def initialize(widgets):
         gamemodel.emit("players_changed")
         return True
 
+    widgets["white_elo_entry"].connect("changed", lambda p: refresh_elo_rating_change(widgets))
+    widgets["black_elo_entry"].connect("changed", lambda p: refresh_elo_rating_change(widgets))
+
     widgets["game_info"].connect("delete-event", hide_window)
     widgets["game_info_cancel_button"].connect("clicked", hide_window)
     widgets["game_info_ok_button"].connect("clicked", accept_new_properties)
+
+
+def refresh_elo_rating_change(widgets):
+    persp = perspective_manager.get_perspective("games")
+    gamemodel = persp.cur_gmwidg().gamemodel
+    welo = widgets["white_elo_entry"].get_text()
+    belo = widgets["black_elo_entry"].get_text()
+    widgets["w_elo_change"].set_text(get_elo_rating_change_str(gamemodel, WHITE, welo, belo))
+    widgets["b_elo_change"].set_text(get_elo_rating_change_str(gamemodel, BLACK, welo, belo))


### PR DESCRIPTION
Hello,

Now that we can set the ELO in the properties of the game, we are able to get some related information about its evolution based on the time control of the game, the levels of the players, the chances to win, the termination... The properties of the game are then extended by the PR, as well as the export to PGN along with additional checks to secure the data (decoration for backslashes and quotes).

The concept is explained in the FIDE handbook and testable online at :
ratings.fide.com/calculator_rtd.phtml

The results are not the same than FICS.

Regards