### PR TITLE
Rotate the board in setup position

### DIFF
--- a/glade/newInOut.glade
+++ b/glade/newInOut.glade
@@ -1493,21 +1493,6 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkToggleButton" id="side_button">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
-                                            <property name="halign">start</property>
-                                            <child>
-                                              <placeholder/>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
                                           <object class="GtkSpinButton" id="fifty_spin">
                                             <property name="visible">True</property>
                                             <property name="can_focus">True</property>
@@ -1547,7 +1532,45 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <placeholder/>
+                                          <object class="GtkBox" id="box3">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <child>
+                                              <object class="GtkToggleButton" id="side_button">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                                <property name="halign">start</property>
+                                                <child>
+                                                  <placeholder/>
+                                                </child>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                            <child>
+                                              <object class="GtkButton" id="rotate_button">
+                                                <property name="label" translatable="yes">Rotate the board</property>
+                                                <property name="name">rotate_button</property>
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">1</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                          <packing>
+                                            <property name="left_attach">1</property>
+                                            <property name="top_attach">0</property>
+                                            <property name="width">2</property>
+                                          </packing>
                                         </child>
                                         <child>
                                           <placeholder/>

--- a/lib/pychess/widgets/newGameDialog.py
+++ b/lib/pychess/widgets/newGameDialog.py
@@ -3,6 +3,7 @@ import os.path
 import gettext
 import locale
 
+from math import pi
 from operator import attrgetter
 from itertools import groupby
 from io import StringIO
@@ -562,6 +563,7 @@ class SetupPositionExtension(_GameInitializationMode):
         cls.widgets["side_button"].set_image(cls.white)
 
         cls.widgets["side_button"].connect("toggled", cls.side_button_toggled)
+        cls.widgets["rotate_button"].connect("button-press-event", cls.rotate_button_pressed)
         cls.widgets["moveno_spin"].connect("value-changed",
                                            cls.moveno_spin_changed)
         cls.widgets["fifty_spin"].connect("value-changed",
@@ -591,6 +593,14 @@ class SetupPositionExtension(_GameInitializationMode):
         else:
             button.set_image(cls.white)
         cls.fen_changed()
+
+    @classmethod
+    def rotate_button_pressed(self, widget, button_event):
+        view = self.board_control.view
+        if view.rotation:
+            view.rotation = 0
+        else:
+            view.rotation = pi
 
     @classmethod
     def fen_changed(cls):


### PR DESCRIPTION
Hello,

This is the first step to support the rotation of the board during the setup of a position. This is especially useful when you play as Black.

The next steps could be :
- the coordinates of the board in the left&bottom borders don't have yet a rotated equivalent on their opposite sides when the board is rotated
- once we start from the position, the principal board takes the orientation of the setup

Regards