### PR TITLE
Fix TimeControl in annotationPanel

### DIFF
--- a/lib/pychess/perspectives/games/annotationPanel.py
+++ b/lib/pychess/perspectives/games/annotationPanel.py
@@ -2,6 +2,7 @@
 
 import re
 import datetime
+from math import floor
 
 from gi.repository import Gtk
 from gi.repository import Pango
@@ -1008,19 +1009,24 @@ class Sidepanel:
         text = ""
         time_control = gm.tags.get('TimeControl')
         if time_control:
-            if "+" in time_control:
-                mins, inc = time_control.split('+')
-                mins = int(mins) / 60
-                mins = "{:.0f}".format(mins)
-                if inc != '0':
-                    text += mins + ' mins + ' + inc + ' secs '
-                else:
-                    text += mins + ' mins '
+            if re.match("^[0-9]+\+[0-9]+$", time_control) is None:
+                text += time_control
             else:
-                text += time_control + ' '
+                mins, inc = time_control.split('+')
+                tmin = int(floor(int(mins) / 60))
+                tsec = int(mins) - 60 * tmin
+                if tmin > 0:
+                    text += str(tmin) + " " + (_("mins") if tmin > 1 else _("min"))
+                if tsec > 0:
+                    text += " " if text != "" else ""
+                    text += str(tsec) + " " + (_("secs") if tsec > 1 else _("sec"))
+                if inc != "" and inc != "0":
+                    text += " + " + inc + " " + (_("secs") if int(inc) > 1 else _("sec")) + "/" + _("move")
 
         event = gm.tags['Event']
         if event and event != "?":
+            if len(text) > 0:
+                text += ', '
             text += event
 
         site = gm.tags['Site']


### PR DESCRIPTION
Hello,

pyChess is unable to load the annotation panel for that game :

```
[Event "Delightful match"]
[Site "Batcave"]
[Date "2017.11.25"]
[Round "1"]
[White "Batman"]
[WhiteElo "3630"]
[Black "Joker"]
[BlackElo "1515"]
[Result "1-0"]
[PlyCount "5"]
[Termination "normal"]
[TimeControl "90 minutes for 40 moves, +30 minutes, +30 seconds per move"]

1. e3 f6
2. Nc3 g5?? {Very bad move !}
3. Qh5#
1-0
```

because :

```
Traceback (most recent call last):
  File "/home/pychess/lib/pychess/perspectives/games/annotationPanel.py", line 1146, in players_changed
    self.update()
  File "/home/pychess/lib/pychess/perspectives/games/annotationPanel.py", line 1082, in update
    self.insert_header(self.gamemodel)
  File "/home/pychess/lib/pychess/perspectives/games/annotationPanel.py", line 1012, in insert_header
    mins, inc = time_control.split('+')
ValueError: too many values to unpack (expected 2)
```

The PR fixes that.

I also added more details for "90+0" (for example) which was displayed as 2 minutes instead of 1 minute 30 seconds.

Regards