### PR TITLE
Indented export to PGN

### DIFF
--- a/glade/PyChess.glade
+++ b/glade/PyChess.glade
@@ -4049,7 +4049,32 @@ It will search positions from http://www.k4it.de/</property>
                         <property name="left_padding">5</property>
                         <child>
                           <object class="GtkCheckButton" id="saveRatingChange">
-                            <property name="label" translatable="yes">Save rating change values</property>
+                            <property name="label" translatable="yes">Save _rating change values</property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkAlignment" id="alignment29">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">5</property>
+                        <child>
+                          <object class="GtkCheckButton" id="indentPgn">
+                            <property name="label" translatable="yes">Indent _PGN file</property>
                             <property name="use_action_appearance">False</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>

--- a/lib/pychess/widgets/preferencesDialog.py
+++ b/lib/pychess/widgets/preferencesDialog.py
@@ -838,4 +838,5 @@ class SaveTab:
         uistuff.keep(widgets["saveEmt"], "saveEmt")
         uistuff.keep(widgets["saveEval"], "saveEval")
         uistuff.keep(widgets["saveRatingChange"], "saveRatingChange")
+        uistuff.keep(widgets["indentPgn"], "indentPgn")
         uistuff.keep(widgets["saveOwnGames"], "saveOwnGames", first_value=True)


### PR DESCRIPTION
Hello,

This PR adds an optional indentation for the export to PGN. The multi-level analysis is sometimes very complex and once your file is saved, you have everything concatenated and wrapped, so it is not easily readable/changeable in text-mode.

Let's take again a stupid example :

- Before :

```
{Game analysis}
1. e4 e6 2. d4 (2. Nc3 d5 3. exd5 exd5 (3... e5 4. d6 cxd6
(4... Qxd6 {Possible})) 4. Qf3 {Not bad}) 2... d5 3. Nc3 {Several
possibilities} (3. Nd2 c5 4. exd5 $3 Qxd5) (3. a3) 3... h6 *
```

- After :

```
{Game analysis}
1. e4 e6 
2. d4
    (2. Nc3 d5 3. exd5 exd5
        (3... e5 4. d6 cxd6
            (4... Qxd6 {Possible})
        )
    4. Qf3 {Not bad})
2... d5 
3. Nc3 {Several possibilities}
    (3. Nd2 c5 4. exd5 $3 Qxd5)
    (3. a3)
3... h6
*
```

Regards
