### PR TITLE
Redesigned score panel

### DIFF
--- a/glade/PyChess.glade
+++ b/glade/PyChess.glade
@@ -1643,6 +1643,26 @@
                                       </packing>
                                     </child>
                                     <child>
+                                      <object class="GtkCheckButton" id="scoreLinearScale">
+                                        <property name="label" translatable="yes">Use a linear scale for the score</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="tooltip_text" translatable="yes">Unticked : the exponential stretching displays the full range of the score and enlarges the values around the null average.
+
+Ticked : the linear scale focuses on a limited range around the null average. It highlights the tiny errors and blunders better.</property>
+                                        <property name="halign">start</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">5</property>
+                                      </packing>
+                                    </child>
+                                    <child>
                                       <object class="GtkCheckButton" id="showCaptured">
                                         <property name="label" translatable="yes">Show _captured pieces</property>
                                         <property name="use_action_appearance">False</property>

--- a/lib/pychess/widgets/preferencesDialog.py
+++ b/lib/pychess/widgets/preferencesDialog.py
@@ -76,7 +76,7 @@ class GeneralTab:
         # Give to uistuff.keeper
 
         for key in ("firstName", "secondName", "showEmt", "showEval",
-                    "hideTabs", "closeAll", "faceToFace",
+                    "hideTabs", "closeAll", "faceToFace", "scoreLinearScale",
                     "showCaptured", "figuresInNotation",
                     "moveAnimation", "noAnimation",
                     "autoRotate", "showFICSgameno"):


### PR DESCRIPTION
Hello,

The current view of the scores in PyChess is vertical, so :
- we have to scroll the view to understand how the score evolves
- we can't take a screenshot of the score
- the informative area between -3/+3 cp is limited in width

This PR suggests a new design :
- the initial black/white style is not modified
- horizontal layout : it will comply with all the existing GUI and websites
- dynamic size of the moves to avoid scrolling : from 1 to 24 px
- linear (-8/+8 cp) and exponential (+max/-min cp) stretching as an option
- horizontal markers for the expectable levels of defeat (±3, ±8 and ±16 cp)

Preview :
![image](https://user-images.githubusercontent.com/24614488/34424051-cb90125a-ec20-11e7-884e-6f4e6b31e2f2.png)

Thanks for any comment on this.

Regards