### PR TITLE
Fix disappearing variation lines

### DIFF
--- a/lib/pychess/perspectives/games/annotationPanel.py
+++ b/lib/pychess/perspectives/games/annotationPanel.py
@@ -1107,8 +1107,7 @@ class Sidepanel:
 
         if self.gamemodel.ply > 0:
             self.textbuffer.delete(start, end)
-        else:
-            self.update()
+        self.update()
 
     def game_changed(self, game, ply):
         board = game.getBoardAtPly(ply, variation=0).board


### PR DESCRIPTION
Hello,

- Play this game :

```
1. e4 e5
	(1... e6)
	(1... c6)
2. f4 * 
```

- Undo the last move

The variation lines disappear in the annotation panel. The PR fixes that.

Regards