### PR TITLE
Fix parse PlyCount

### DIFF
--- a/lib/pychess/perspectives/database/gamelist.py
+++ b/lib/pychess/perspectives/database/gamelist.py
@@ -133,8 +133,11 @@ class GameList(Gtk.TreeView):
             site = rec["Site"]
             round_ = rec["Round"]
             date = str(get_date(rec))
-            ply = rec["PlyCount"]
-            length = str(int(ply) // 2) if ply else ""
+            try:
+                ply = rec["PlyCount"]
+                length = str(int(ply) // 2) if ply else ""
+            except ValueError:
+                length = ""
             eco = rec["ECO"]
             tc = rec["TimeControl"]
             variant = rec["Variant"]


### PR DESCRIPTION
Hello,

A game with an invalid `PlyCount` cannot be opened.

```
unknown ERROR:   File "lib\pychess\perspectives\database\__init__.py", line 260, in on_chessfile_opened0
unknown ERROR:   File "lib\pychess\perspectives\database\gamelist.py", line 137, in load_games
unknown ERROR: ValueError
unknown ERROR: : 
unknown ERROR: invalid literal for int() with base 10: '*'
```

The PR tries to ignore the bad tag to make the game openable.

Regards