### PR TITLE
Copy subfen in FilterPanel

### DIFF
--- a/glade/PyChess.glade
+++ b/glade/PyChess.glade
@@ -6650,70 +6650,6 @@ If it can use both  you can set here which one you like.</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">3</property>
                     <child>
-                      <object class="GtkAlignment" id="setup_pattern_dock">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <placeholder/>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButtonBox" id="buttonbox1">
-                        <property name="can_focus">False</property>
-                        <property name="layout_style">start</property>
-                        <child>
-                          <object class="GtkButton" id="copy_sub_fen">
-                            <property name="label" translatable="yes">Copy FEN</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="clear_sub_fen">
-                            <property name="label" translatable="yes">Clear</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="paste_sub_fen">
-                            <property name="label" translatable="yes">Paste FEN</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">2</property>
-                          </packing>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkBox" id="box14">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -6722,7 +6658,7 @@ If it can use both  you can set here which one you like.</property>
                           <object class="GtkLabel" id="label72">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">sub-fen</property>
+                            <property name="label" translatable="yes">Sub-FEN :</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -6742,11 +6678,39 @@ If it can use both  you can set here which one you like.</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkButton" id="copy_sub_fen">
+                            <property name="label">gtk-copy</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="use_stock">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="position">2</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkAlignment" id="setup_pattern_dock">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>

--- a/lib/pychess/perspectives/database/FilterPanel.py
+++ b/lib/pychess/perspectives/database/FilterPanel.py
@@ -1,7 +1,7 @@
 # -*- coding: UTF-8 -*-
 import ast
 
-from gi.repository import GLib, Gtk, GObject
+from gi.repository import GLib, Gdk, Gtk, GObject
 
 from pychess.Utils.const import chr2Sign, WHITE, BLACK
 from pychess.Utils.Piece import Piece
@@ -77,6 +77,8 @@ class FilterPanel(Gtk.TreeView):
         dock = "moved_%s_dock" % piece
         self.widgets[dock].add(PieceWidget(Piece(BLACK, chr2Sign[piece])))
         self.widgets[dock].get_child().show()
+
+        self.widgets["copy_sub_fen"].connect("clicked", self.on_copy_sub_fen)
 
         # We will store our filtering queries in a ListStore
         # column 0: query as text
@@ -616,6 +618,12 @@ class FilterPanel(Gtk.TreeView):
 
     def fen_changed(self):
         self.widgets["sub_fen"].set_text(self.get_fen())
+
+    def on_copy_sub_fen(self, widget):
+        clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        text = self.widgets["sub_fen"].get_text()
+        if len(text) > 0:
+            clipboard.set_text(text, -1)
 
     def game_changed(self, model, ply):
         GLib.idle_add(self.fen_changed)


### PR DESCRIPTION
Hello,

The existing button to copy the subfen was hidden in the file `pychess.glade`. It is now implemented as follows :

![image](https://user-images.githubusercontent.com/24614488/35477396-d343f8e6-03c1-11e8-93b0-cb722cdd22a8.png)

The subfen is above the board to avoid a concentration of buttons in the bottom-right corner of the dialog.

Regards