### PR TITLE
Parse negative increment

### DIFF
--- a/lib/pychess/Savers/pgn.py
+++ b/lib/pychess/Savers/pgn.py
@@ -120,14 +120,14 @@ def parseClockTimeTag(tag):
 def parseTimeControlTag(tag):
     """
     Parses 'TimeControl' PGN header and returns the time and gain the
-    players have on game satrt in seconds
+    players have on game start in seconds
     """
-    match = re.match("(\d+)(?:\+(\d+))?", tag)
+    match = re.match("^(\d+)\+?(\-?\d+)?$", tag)
     if match:
         secs, gain = match.groups()
         return int(secs), int(gain) if gain is not None else 0, 0
     else:
-        match = re.match("(\d+)(?:\/(\d+))?", tag)
+        match = re.match("^(\d+)\/(\d+)$", tag)
         if match:
             moves, secs = match.groups()
             return int(secs), 0, int(moves)

--- a/lib/pychess/Utils/GameModel.py
+++ b/lib/pychess/Utils/GameModel.py
@@ -149,7 +149,7 @@ class GameModel(GObject.GObject):
         if self.timed:
             self.zero_reached_cid = self.timemodel.connect('zero_reached', self.zero_reached)
             if self.timemodel.moves == 0:
-                self.tags["TimeControl"] = "%d+%d" % (self.timemodel.minutes * 60, self.timemodel.gain)
+                self.tags["TimeControl"] = "%d%s%d" % (self.timemodel.minutes * 60, "+" if self.timemodel.gain >= 0 else "-", abs(self.timemodel.gain))
             else:
                 self.tags["TimeControl"] = "%d/%d" % (self.timemodel.moves, self.timemodel.minutes * 60)
             # Notice: tags["WhiteClock"] and tags["BlackClock"] are never set


### PR DESCRIPTION
Hello,

While I was adding the estimated duration of a game in the previous PR, I noticed that pyChess offers the possibility to play with a "negative increment" for the local games. That's pretty original and as a logic was implemented to handle the sign of the increment, I assume that it was a deliberate choice.

The problem is that the PGN tag TimeControl is not parseable in that case. With that new PR, "10+-5" will become "10-5" and the UI will be able to parse it and display a nice text in annotationPanel. Indeed, this is not in line with the PGN specification because it requires 2 positives values, but having a negative gain is basically unexpected.

Since the offered gameplay is interesting, I propose to keep this "negative increment" (go against the PGN rules). The Internet part is not changed because the increment is normally positive only.

Regards