### PR TITLE
Keep node selected after update

### DIFF
--- a/lib/pychess/perspectives/games/annotationPanel.py
+++ b/lib/pychess/perspectives/games/annotationPanel.py
@@ -657,7 +657,6 @@ class Sidepanel:
                 end = self.textbuffer.get_iter_at_offset(n["end"])
                 node = n
                 break
-
         if node is None:
             return
 
@@ -674,6 +673,7 @@ class Sidepanel:
             for node in self.nodelist[index + 1:]:
                 node["start"] += diff
                 node["end"] += diff
+        self.update_selected_node()
 
     def insert_node(self, board, iter, index, level, parent):
         start = iter.get_offset()


### PR DESCRIPTION
Hello,

If you apply a NAG symbol on the node which is selected, it will lose its attribute 'selected'.
It is because the node is deleted and recreated. The reapplication of the attribute 'selected' is missing.
The PR fixes that.

Regards