### PR TITLE
Figurines for crazyhouse

### DIFF
--- a/lib/pychess/Utils/lutils/lmove.py
+++ b/lib/pychess/Utils/lutils/lmove.py
@@ -653,6 +653,7 @@ san2WhiteFanDic = {
     ord("B"): FAN_PIECES[WHITE][BISHOP],
     ord("S"): FAN_PIECES[WHITE][BISHOP],
     ord("N"): FAN_PIECES[WHITE][KNIGHT],
+    ord("P"): FAN_PIECES[WHITE][PAWN],
     ord("+"): "†",
     ord("#"): "‡"
 }
@@ -666,6 +667,7 @@ san2BlackFanDic = {
     ord("B"): FAN_PIECES[BLACK][BISHOP],
     ord("S"): FAN_PIECES[BLACK][BISHOP],
     ord("N"): FAN_PIECES[BLACK][KNIGHT],
+    ord("P"): FAN_PIECES[BLACK][PAWN],
     ord("+"): "†",
     ord("#"): "‡"
 }

--- a/lib/pychess/perspectives/games/annotationPanel.py
+++ b/lib/pychess/perspectives/games/annotationPanel.py
@@ -977,8 +977,8 @@ class Sidepanel:
 
         # Application of the filter on each element of the text
         if self.fan:
-            re_decoration = re.compile('^([^a-hrnkqx1-8]*|[0-9]+\.+)?([a-hrnkqx1-8=]+)([^a-hrnkqx1-8]*)$', re.IGNORECASE)
-            re_move = re.compile('^([RNBQK]?)([a-h]?[1-8]?x?[a-h][1-8]=?)([RNBQK]?)(.*)$')
+            re_decoration = re.compile('^([^a-hprnkqx1-8]*|[0-9]+\.+)?([a-hprnkqx1-8=@]+)([^a-hprnkqx1-8]*)$', re.IGNORECASE)
+            re_move = re.compile('^([PRNBQK]?)(@?[a-h]?[1-8]?x?[a-h][1-8]=?)([RNBQK]?)(.*)$')
             return " ".join([process_word(word) for word in text.split(" ")])
         else:
             return text


### PR DESCRIPTION
Hello,

Let's consider this game :

```
[Variant "Crazyhouse"]

1. e4 c5 2. Bc4 e5 3. Qh5 Qe7 4. Nf3 d6 5. Bxf7+ Qxf7 6. Qxf7+ Kxf7 7. Ng5+
Ke8 8. Q@f7+ Kd8 9. P@c7# 1-0 
```

`9. P@c7#` is now displayed with the figurine in annotationPanel and bookPanel.

If you set a comment like `"Q@h4!" is good`, you will see the figurine in annotationPanel. It was not the case because of `@`.

Regards