### PR TITLE
Amended syntax

### DIFF
--- a/lib/pychess/Savers/database.py
+++ b/lib/pychess/Savers/database.py
@@ -16,18 +16,10 @@ def save(path, model, offset):
     game_site = model.tags["Site"]
 
     year, month, day = model.getGameDate()
-    try:
-        year = int(year)
-    except ValueError:
-        year = 0
-    try:
-        month = int(month)
-    except ValueError:
-        month = 0
-    try:
-        day = int(day)
-    except ValueError:
-        day = 0
+    year = 0 if year is None else year
+    month = 0 if month is None else month
+    day = 0 if day is None else day
+
     game_round = model.getTag("Round", "")
 
     white = repr(model.players[WHITE])

--- a/lib/pychess/Savers/pgn.py
+++ b/lib/pychess/Savers/pgn.py
@@ -668,7 +668,10 @@ class PGNFile(ChessFile):
             if line.startswith('[') and line.endswith(']'):
                 tag_match = TAG_REGEX.match(line)
                 if tag_match:
-                    header[tag_match.group(1)] = tag_match.group(2)
+                    value = tag_match.group(2)
+                    value = value.replace("\\\"", "\"")
+                    value = value.replace("\\\\", "\\")
+                    header[tag_match.group(1)] = value
             else:
                 break
         return header

--- a/lib/pychess/Utils/GameModel.py
+++ b/lib/pychess/Utils/GameModel.py
@@ -258,12 +258,21 @@ class GameModel(GObject.GObject):
         date = self.getTag('Date', '')
         elements = re.match("^([0-9\?]{4})(\.([0-9\?]{2})(\.([0-9\?]{2}))?)?$", date)
         if elements is None:
-            y, m, d = '', '', ''
+            y, m, d = None, None, None
         else:
             elements = elements.groups()
-            y = elements[0] if elements[0] is not None else ''
-            m = elements[2] if elements[2] is not None else ''
-            d = elements[4] if elements[4] is not None else ''
+            try:
+                y = int(elements[0])
+            except Exception:
+                y = None
+            try:
+                m = int(elements[2])
+            except Exception:
+                m = None
+            try:
+                d = int(elements[4])
+            except Exception:
+                d = None
         return y, m, d
 
     def color(self, player):

--- a/lib/pychess/perspectives/games/__init__.py
+++ b/lib/pychess/perspectives/games/__init__.py
@@ -196,11 +196,13 @@ class Games(GObject.GObject, Perspective):
         filename = filename.replace("#n1", game.tags["White"])
         filename = filename.replace("#n2", game.tags["Black"])
         year, month, day = game.getGameDate()
+        year = '' if year is None else str(year)
+        month = '' if month is None else str(month)
+        day = '' if day is None else str(day)
         filename = filename.replace("#y", "%s" % year)
         filename = filename.replace("#m", "%s" % month)
         filename = filename.replace("#d", "%s" % day)
-        pgn_path = conf.get("autoSavePath", os.path.expanduser("~")) + \
-            "/" + filename + ".pgn"
+        pgn_path = conf.get("autoSavePath", os.path.expanduser("~")) + "/" + filename + ".pgn"
         append = True
         try:
             if not os.path.isfile(pgn_path):

--- a/lib/pychess/widgets/gameinfoDialog.py
+++ b/lib/pychess/widgets/gameinfoDialog.py
@@ -53,18 +53,9 @@ def initialize(widgets):
         # Prepare the date of the picker
         calendar = Gtk.Calendar()
         curyear, curmonth, curday = calendar.get_date()
-        try:
-            year = int(year)
-        except ValueError:
-            year = curyear
-        try:
-            month = int(month) - 1
-        except ValueError:
-            month = curmonth
-        try:
-            day = int(day)
-        except ValueError:
-            day = curday
+        year = curyear if year is None else year
+        month = curmonth if month is None else month - 1
+        day = curday if day is None else day
         calendar.select_month(month, year)
         calendar.select_day(day)
 


### PR DESCRIPTION
Hello,

This PR changes the syntax of a method I added recently. The elements of the date are returned as `int`, no more as `str`. It will limit the handling of the exceptions caused by `int()`.

I also added the unescape of the PGN tags for `"` and `\`. The escape is already implemented for the export.

Regards