### PR TITLE
Learn without Stockfish

### DIFF
--- a/lib/pychess/perspectives/learn/EndgamesPanel.py
+++ b/lib/pychess/perspectives/learn/EndgamesPanel.py
@@ -13,7 +13,7 @@ from pychess.Utils.lutils.LBoard import LBoard
 from pychess.Utils.lutils.lmove import FILE, RANK
 from pychess.Variants import variants
 from pychess.Players.Human import Human
-from pychess.Players.engineNest import discoverer, stockfish_name
+from pychess.Players.engineNest import discoverer
 from pychess.System import conf
 from pychess.perspectives import perspective_manager
 from pychess.Savers import fen as fen_loader
@@ -123,7 +123,7 @@ def start_endgame_from(pieces):
         name = conf.get("firstName", _("You"))
         p0 = (LOCAL, Human, (WHITE, name), name)
 
-        engine = discoverer.getEngineByName(stockfish_name)
+        engine = discoverer.getEngineByName(discoverer.getEngineLearn())
         name = discoverer.getName(engine)
         p1 = (ARTIFICIAL, discoverer.initPlayerEngine,
               (engine, BLACK, 20, variants[NORMALCHESS], 60, 0, 0, True), name)

--- a/lib/pychess/perspectives/learn/PuzzlesPanel.py
+++ b/lib/pychess/perspectives/learn/PuzzlesPanel.py
@@ -9,7 +9,7 @@ from pychess.Utils.GameModel import GameModel
 from pychess.Utils.TimeModel import TimeModel
 from pychess.Variants import variants
 from pychess.Players.Human import Human
-from pychess.Players.engineNest import discoverer, stockfish_name
+from pychess.Players.engineNest import discoverer
 from pychess.perspectives import perspective_manager
 from pychess.Savers.olv import OLVFile
 from pychess.Savers.pgn import PGNFile
@@ -93,7 +93,7 @@ def start_puzzle_from(filename):
 
     chessfile.loadToModel(rec, 0, gamemodel)
 
-    engine = discoverer.getEngineByName(stockfish_name)
+    engine = discoverer.getEngineByName(discoverer.getEngineLearn())
 
     color = gamemodel.boards[0].color
     if color == WHITE:
@@ -114,7 +114,7 @@ def start_puzzle_from(filename):
         p1 = (LOCAL, Human, (BLACK, name), name)
 
     def fix_name(gamemodel, name, color):
-        asyncio.async(gamemodel.start_analyzer(HINT, force_engine=stockfish_name))
+        asyncio.async(gamemodel.start_analyzer(HINT, force_engine=discoverer.getEngineLearn()))
         gamemodel.players[1 - color].name = oppname
         gamemodel.emit("players_changed")
 

--- a/lib/pychess/widgets/preferencesDialog.py
+++ b/lib/pychess/widgets/preferencesDialog.py
@@ -21,7 +21,7 @@ from gi.repository import Gtk, GdkPixbuf, Gdk
 
 from pychess.System.prefix import addDataPrefix, getDataPrefix
 from pychess.System import conf, gstreamer, uistuff
-from pychess.Players.engineNest import discoverer, stockfish_name
+from pychess.Players.engineNest import discoverer
 from pychess.Utils.const import HINT, SPY, SOUND_MUTE, SOUND_BEEP, SOUND_URI, SOUND_SELECT
 from pychess.Utils.IconLoader import load_icon, get_pixbuf
 from pychess.gfx import Pieces
@@ -218,7 +218,7 @@ class HintTab:
 
         # Save, load and make analyze combos active
 
-        engine = discoverer.getEngineByName(stockfish_name)
+        engine = discoverer.getEngineByName(discoverer.getEngineLearn())
         if engine is None:
             engine = discoverer.getEngineN(-1)
         default = engine.get("md5")


### PR DESCRIPTION
Hello,

For the view Learn, this PR finds another engine when Stockfish is not available for the reasons mentioned in #1583. It stays the primary engine to be found.

This change will be more resilient for PyChess on Windows than the current logic.

Regards