### PR TITLE
Deeper annotationPanel #1610

### DIFF
--- a/lib/pychess/perspectives/games/annotationPanel.py
+++ b/lib/pychess/perspectives/games/annotationPanel.py
@@ -18,6 +18,7 @@ from pychess.Savers.pgn import move_count, nag2symbol, parseTimeControlTag
 from pychess.widgets.ChessClock import formatTime
 from pychess.widgets.LearnInfoBar import LearnInfoBar
 from pychess.widgets import insert_formatted, preferencesDialog, mainwindow
+from pychess.widgets.Background import isDarkTheme
 
 
 # --- Constants
@@ -122,10 +123,13 @@ class Sidepanel:
         self.tag_new_line = self.textbuffer.create_tag("new_line")
 
         self.tag_move = self.textbuffer.create_tag("move", font_desc=self.font)
-        colors = ["#4b4b4b", "#51a745", "#ee3e34", "#3965a8", "#a882bc", "#f09243", "#772120", "#c0c000"]  # black, green, red, blue, purple, orange, brown, ochre
+        if isDarkTheme(self.textview):
+            palette = ["#e5e5e5", "#35e119", "#ee3e34", "#24c6ee", "#a882bc", "#f09243", "#e475e5", "#c0c000"]  # white, green, red, aqua, purple, orange, fuchsia, ochre
+        else:
+            palette = ["#4b4b4b", "#51a745", "#ee3e34", "#3965a8", "#a882bc", "#f09243", "#772120", "#c0c000"]  # black, green, red, blue, purple, orange, brown, ochre
         self.tag_vari_depth = []
         for i in range(64):
-            tag = self.textbuffer.create_tag("variation-depth-%d" % i, font_desc=self.font, foreground=colors[i % len(colors)], style="italic", left_margin=15 * (i + 1))
+            tag = self.textbuffer.create_tag("variation-depth-%d" % i, font_desc=self.font, foreground=palette[i % len(palette)], style="italic", left_margin=15 * (i + 1))
             self.tag_vari_depth.append(tag)
 
         self.textbuffer.create_tag("scored0")

--- a/lib/pychess/widgets/Background.py
+++ b/lib/pychess/widgets/Background.py
@@ -230,3 +230,11 @@ def newTheme(widget, background=None):
     fyle = open(temppng, "wb")
     fyle.write(bytes(colors))
     surface.write_to_png(fyle)
+
+
+def isDarkTheme(widget):
+    color = widget.get_style_context().get_background_color(Gtk.StateFlags.NORMAL)
+    minimal = min(color.red, color.green, color.blue)
+    maximal = max(color.red, color.green, color.blue)
+    lightness = (minimal + maximal) / 2
+    return lightness < 0.5


### PR DESCRIPTION
Hello,

Here is the new suggested design for annotationPanel with enhanced alignments and colors in the limit of 64 levels :

![image](https://user-images.githubusercontent.com/24614488/36926690-5e87b286-1e79-11e8-8887-b16e57239055.png)

It is more good looking than :

![image](https://user-images.githubusercontent.com/24614488/36926719-7db001cc-1e79-11e8-9d9a-9e422bec4f1e.png)

The PGN to reproduce the case is :

```
1. e4 e5 
2. d4
    (2. Nf3 Nf6
        (2... d6 3. Nc3 Nf6
            (3... d5 4. Nxd5 c6 5. Nb4
                (5. Nc3 Qd4 6. Nxd4 exd4 7. Nd5
                    (7. Ne2 d3 8. Nd4
                        (8. f3 dxe2 9. Qxe2
                            (9. Kxe2 Be6 10. c4
                                (10. b3 Nd7 11. c4
                                    (11. d4 c5 12. dxc5
                                        (12. d5 Bxd5 13. Qxd5)
                                    12... Nxc5)
                                11... Ngf6)
                            10... Bxc4+)
                        )
                    )
                )
            5... c5)
        4. Nd5)
    3. Nc3 d6)
2... f6 *
```

Regards