### PR TITLE
Refresh annotationPanel

### DIFF
--- a/lib/pychess/perspectives/games/annotationPanel.py
+++ b/lib/pychess/perspectives/games/annotationPanel.py
@@ -344,6 +344,10 @@ class Sidepanel:
                         position = index
                         break
 
+                menuitem = Gtk.MenuItem(_("Refresh"))
+                menuitem.connect('activate', self.menu_refresh)
+                self.menu.append(menuitem)
+
                 if len(self.gamemodel.boards) > 1 and board == self.gamemodel.boards[1].board and \
                         not self.gamemodel.boards[0].board.children:
                     menuitem = Gtk.MenuItem(_("Add start comment"))
@@ -421,6 +425,9 @@ class Sidepanel:
                 self.menu.show_all()
                 self.menu.popup(None, None, None, None, event.button, event.time)
         return True
+
+    def menu_refresh(self, widget):
+        self.update()
 
     def menu_edit_comment(self, widget=None, board=None, index=0):
         """


### PR DESCRIPTION
Hello,

When you prepare a study in pychess, you can move the pieces at various levels and order. The problem after some time is that it misaligns the order, the style and the hierarchy of the elements of the textarea in a way that only a full refresh can restore the view correctly.

The ability to refresh the view by playing around with the comments is no more possible since 626d0feb3da38b8129aee359e405f462888c777d. The idea is to add a popup item "Refresh" in annotationPanel, else the study cannot be completed in correct conditions.

Regards