### PR TITLE
Fix value of K in ELO estimation

### DIFF
--- a/lib/pychess/Utils/TimeModel.py
+++ b/lib/pychess/Utils/TimeModel.py
@@ -264,4 +264,4 @@ class TimeModel(GObject.GObject):
 
     def isBlitzFide(self):
         val = 60 * self.minutes + 60 * (self.gain if self.handle_gain else 0)
-        return val <= 600  # Less or equal than 10 minutes for 60 moves and for each player
+        return val > 0 and val <= 600  # Less or equal than 10 minutes for 60 moves and for each player


### PR DESCRIPTION
Hello

A game cannot be considered as blitz if the time control is unknown. This patch will principally provide a more accurate estimation of the elo variation for grand masters (K=10 if >=2400). To be checked in the properties of the game.

Regards