### PR TITLE
Longer timeout for the readiness of the engines

### DIFF
--- a/lib/pychess/Players/ProtocolEngine.py
+++ b/lib/pychess/Players/ProtocolEngine.py
@@ -3,7 +3,7 @@ from gi.repository import GObject
 from pychess.Players.Engine import Engine
 from pychess.Utils.const import NORMAL, ANALYZING, INVERSE_ANALYZING
 
-TIME_OUT_SECOND = 10
+TIME_OUT_SECOND = 30
 
 
 class ProtocolEngine(Engine):


### PR DESCRIPTION
Hello,

The timeout of 10 seconds is sometimes not enough to let PyChess start a game between 2 memory intensive engines, especially if the hardware resources are limited or restricted in a virtual environment.

I finally got a better situation by extending the timeout, which is the purpose of that PR.

Thanks