### PR TITLE
Use Scoutfish in direct database query

### DIFF
--- a/lib/pychess/Players/ProtocolEngine.py
+++ b/lib/pychess/Players/ProtocolEngine.py
@@ -3,7 +3,7 @@ from gi.repository import GObject
 from pychess.Players.Engine import Engine
 from pychess.Utils.const import NORMAL, ANALYZING, INVERSE_ANALYZING
 
-TIME_OUT_SECOND = 30
+TIME_OUT_SECOND = 60
 
 
 class ProtocolEngine(Engine):

--- a/lib/pychess/Utils/const.py
+++ b/lib/pychess/Utils/const.py
@@ -9,6 +9,9 @@ LOCAL, ARTIFICIAL, REMOTE = range(3)
 # Engine strengths
 EASY, INTERMEDIATE, EXPERT = range(3)
 
+# Tools
+TOOL_NONE, TOOL_CHESSDB, TOOL_SCOUTFISH = range(3)
+
 # Player colors
 WHITE, BLACK = range(2)
 

--- a/lib/pychess/external/chess_db.py
+++ b/lib/pychess/external/chess_db.py
@@ -7,6 +7,8 @@ import re
 import pexpect
 from pexpect.popen_spawn import PopenSpawn
 
+from pychess.Players.ProtocolEngine import TIME_OUT_SECOND
+
 PGN_HEADERS_REGEX = re.compile(r"\[([A-Za-z0-9_]+)\s+\"(.*)\"\]")
 
 
@@ -14,7 +16,7 @@ class Parser:
     def __init__(self, engine=''):
         if not engine:
             engine = './parser'
-        self.p = PopenSpawn(engine, encoding="utf-8")
+        self.p = PopenSpawn(engine, timeout=TIME_OUT_SECOND, encoding="utf-8")
         self.pgn = ''
         self.db = ''
 

--- a/lib/pychess/external/scoutfish.py
+++ b/lib/pychess/external/scoutfish.py
@@ -7,6 +7,8 @@ import re
 import pexpect
 from pexpect.popen_spawn import PopenSpawn
 
+from pychess.Players.ProtocolEngine import TIME_OUT_SECOND
+
 PGN_HEADERS_REGEX = re.compile(r"\[([A-Za-z0-9_]+)\s+\"(.*)\"\]")
 
 
@@ -14,7 +16,7 @@ class Scoutfish:
     def __init__(self, engine=''):
         if not engine:
             engine = './scoutfish'
-        self.p = PopenSpawn(engine, encoding="utf-8")
+        self.p = PopenSpawn(engine, timeout=TIME_OUT_SECOND, encoding="utf-8")
         self.wait_ready()
         self.pgn = ''
         self.db = ''


### PR DESCRIPTION
Hello,

The following button relies on ChessDB to check if the database contains a valid position. But when the database is very big, the generation of the BIN file may be impossible. So the button becomes useless and tells that no position can be found.
![image](https://user-images.githubusercontent.com/24614488/53306282-5f2e7300-388b-11e9-9682-0479d9995b83.png)

This is partly incorrect because you can filter manually by Scoutfish that handles lighter files. But it requires many clicks for the player. Technically speaking, the approach is not strictly the same, yes.

Adding Scoutfish to the query is the topic of that PR. I appreciate your comments if you see further possible improvements.

Thanks