### PR TITLE
Adjust git info in about dialog

### DIFF
--- a/lib/pychess/Main.py
+++ b/lib/pychess/Main.py
@@ -714,18 +714,15 @@ class PyChess(Gtk.Application):
         # About dialog
         self.aboutdialog = widgets["aboutdialog1"]
         self.aboutdialog.set_program_name(NAME)
-        self.aboutdialog.set_copyright("Copyright © 2006-2018")
+        self.aboutdialog.set_copyright("Copyright © 2006-2019")
         self.aboutdialog.set_version(VERSION_NAME + " " + VERSION)
         if os.path.isdir(prefix.addDataPrefix(".git")):
             try:
-                label = subprocess.check_output(["git", "describe"])
+                self.git_rev = subprocess.check_output(["git", "describe", "--tags"]).decode().strip()
+                self.aboutdialog.set_version('%s Git %s' % (VERSION_NAME, self.git_rev))
             except subprocess.CalledProcessError:
-                label = ""
-            if label:
-                comments = self.aboutdialog.get_comments()
-                self.git_rev = label
-                self.aboutdialog.set_comments("git %s\n%s" %
-                                              (self.git_rev, comments))
+                pass
+        self.aboutdialog.set_comments(self.aboutdialog.get_comments())
 
         with open(prefix.addDataPrefix("ARTISTS"), encoding="utf-8") as f:
             self.aboutdialog.set_artists(f.read().splitlines())


### PR DESCRIPTION
Hello,

This PR corrects the year of copyright and improves the display of the current git version :

* Without Git : `Morphy 0.99.4`
* With Git :
	* Before PR : `Morphy 0.99.4` and `git b'0.10-5351-g8bd30e8\n'`
	* After PR : only `Morphy Git 0.99.4-63-g79c027b`

Happy week