### PR TITLE
Collection of changes

### DIFF
--- a/lib/pychess/widgets/gamewidget.py
+++ b/lib/pychess/widgets/gamewidget.py
@@ -482,7 +482,7 @@ class GameWidget(GObject.GObject):
                 text = repr(self.gamemodel.players[color])
         if with_elo:
             elo = self.gamemodel.tags.get("WhiteElo" if color == WHITE else "BlackElo")
-            if elo:
+            if elo not in [None, '', '?', '0', 0]:
                 text += " (%s)" % str(elo)
         return text
 

--- a/lib/pychess/widgets/tipOfTheDay.py
+++ b/lib/pychess/widgets/tipOfTheDay.py
@@ -112,7 +112,7 @@ class TipOfTheDay:
 
     def shuffleTips(self):
         # Because of the fixed seed, the same shuffled list will be returned.
-        # The idea is to manage all the tips bove by category but to display
+        # The idea is to manage all the tips above by category but to display
         # them once from a random order that can be reproduced at every run.
         for i in range(len(self.tips) - self.tips_fixed):
             p1 = self.xorshift()

--- a/testing/remotegame.py
+++ b/testing/remotegame.py
@@ -34,21 +34,24 @@ class RemoteGameTestCase(unittest.TestCase):
         self.assertEqual(ok, expected)
 
     def testLichess(self):
-        links = [('http://lichess.org/CA4bR2b8/black/analysis#12', True),           # Game in advanced position
-                 ('https://lichess.org/CA4bR2b8', True),                            # Canonical address
-                 ('https://lichess.org/game/export/CA4bR2b8', True),                # Download link
-                 ('http://fr.lichess.org/@/thibault', False),                       # Not a game (user page)
-                 ('http://lichess.org/blog', False),                                # Not a game (page)
-                 ('http://lichess.dev/ABCD1234', False),                            # Not a game (wrong ID)
-                 ('https://lichess.org/9y4KpPyG', True),                            # Variant game Chess960
-                 ('https://LICHESS.org/nGhOUXdP?p=0', True),                        # Variant game with parameter
-                 ('https://lichess.org/nGhOUXdP?p=0#3', True),                      # Variant game with parameter and anchor
-                 ('https://hu.lichess.org/study/hr4H7sOB?page=1', True),            # Study of one game with unused parameter
-                 ('https://lichess.org/study/hr4H7sOB/fvtzEXvi.pgn#32', True),      # Chapter of a study with anchor
-                 ('https://lichess.org/STUDY/hr4H7sOB.pgn', True),                  # Study of one game
-                 ('https://lichess.org/training/daily', True),                      # Daily puzzle
-                 ('https://lichess.org/training/84969', True),                      # Puzzle
-                 ('https://lichess.org/training/1281301832', False)]                # Not a puzzle (wrong ID)
+        links = [('http://lichess.org/CA4bR2b8/black/analysis#12', True),                           # Game in advanced position
+                 ('https://lichess.org/CA4bR2b8', True),                                            # Canonical address
+                 ('https://lichess.org/game/export/CA4bR2b8', True),                                # Download link
+                 ('http://fr.lichess.org/@/thibault', False),                                       # Not a game (user page)
+                 ('http://lichess.org/blog', False),                                                # Not a game (page)
+                 ('http://lichess.dev/ABCD1234', False),                                            # Not a game (wrong ID)
+                 ('https://lichess.org/9y4KpPyG', True),                                            # Variant game Chess960
+                 ('https://LICHESS.org/nGhOUXdP?p=0', True),                                        # Variant game with parameter
+                 ('https://lichess.org/nGhOUXdP?p=0#3', True),                                      # Variant game with parameter and anchor
+                 ('https://hu.lichess.org/study/hr4H7sOB?page=1', True),                            # Study of one game with unused parameter
+                 ('https://lichess.org/study/76AirB4Y/C1NcczQl', True),                             # Chapter of a study
+                 ('https://lichess.org/study/hr4H7sOB/fvtzEXvi.pgn#32', True),                      # Chapter of a study with anchor
+                 ('https://lichess.org/STUDY/hr4H7sOB.pgn', True),                                  # Study of one game
+                 ('https://lichess.org/training/daily', True),                                      # Daily puzzle
+                 ('https://lichess.org/training/84969', True),                                      # Puzzle
+                 ('https://lichess.org/training/1281301832', False),                                # Not a puzzle (wrong ID)
+                 ('https://lichess.org/broadcast/2019-gct-zagreb-round-4/jQ1dbbX9', True),          # Broadcast
+                 ('https://lichess.org/broadcast/2019-pychess-round-1/pychess1', False)]            # Not a broadcast (wrong ID)
         self.executeTest(InternetGameLichess(), links)
 
     def testChessgames(self):


### PR DESCRIPTION
Hello,

Here is a collection of new little changes :

- The option `UCI_LimitStrength` will not be used in analysis mode. The project Stockfish explains in the PR 2225 how its new option will work soon. So if you reduce the strength for your games against AI, it should not be applied to the analyzer.

- The option `UCI_Elo` will be bounded between the defined min/max when a new game is started. To date, the value is 150 times the strength. However, it produces unsupported values. In the PR mentioned above, Stockfish will theoretically not run under 1350. It will convert the ELO to a fractional Skill Level, and the formula would not accept 750 ELO for example. The formula in PyChess is corrected as follows : level 1 = min UCI_Elo, level 18 = max UCI_Elo proportionally to 18/20. If the min/max are not detected, it will use a default range of 1000-2800, so 100 ELO per strength step. An old free version of Rybka has the same kind of limitation, and based on PyChess log, the UCI value looks more consistent now.

- Various typos.

- The exceptions in remotegame are more explicit by changing their representation.

- Broadcasts from Lichess can be opened as studies. The unit test is updated accordingly.

- Unknown ELO won't be displayed in the main application title. Indeed, if you load a PGN having `[WhiteElo "?"]`, you had before a useless `(?)` in the title.

Thanks for your comments