### PR TITLE
Silence PyGI warning requiring Gtk 3.0

### DIFF
--- a/pychess
+++ b/pychess
@@ -14,6 +14,8 @@ if os.path.isdir(os.path.join(this_dir, "lib/pychess")) and \
 
 # Create splash screen
 try:
+    import gi
+    gi.require_version('Gtk', '3.0')
     from gi.repository import Gtk, Gdk
     splash = Gtk.Window()
     splash.props.type_hint = Gdk.WindowTypeHint.SPLASHSCREEN


### PR DESCRIPTION
This fixes the PyGI warning (below) I was getting upon launching pychess. I confirmed in irc that we indeed require Gtk 3.0 at this point, so we may as well have a clean launch to accompany that fact!

``./pychess:17: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk, Gdk``