### PR TITLE
Allow resetting a single puzzle row

### DIFF
--- a/lib/pychess/Utils/const.py
+++ b/lib/pychess/Utils/const.py
@@ -228,5 +228,8 @@ VIEW_MENU_ITEMS = ("rotate_board1", "show_sidepanels", "hint_mode", "spy_mode")
 EDIT_MENU_ITEMS = ("copy_pgn", "copy_fen", )
 MENU_ITEMS = GAME_MENU_ITEMS + ACTION_MENU_ITEMS + VIEW_MENU_ITEMS + EDIT_MENU_ITEMS
 
+# Column name
+COLUMN_ROW_RESET = "column_row_reset"
+
 # Learn categories
 LECTURE, LESSON, PUZZLE, ENDGAME = range(4)


### PR DESCRIPTION
Targets issue #1688.

* Add a column of CellRendererPixbuf to the PuzzlePanel.
* Change the function row_activated to let it handle the reset buttons.
* When the button is clicked, the new method _reset_progress_file queries the user and handles resetting a single progress file.

Here's what it looks like:
![PyChess puzzle panel screencap](https://discourse.gnome.org/uploads/default/original/1X/e1415160d99244c7630325d8b9886ee4cc3d1fd1.png)

Note: The current change targets solely the puzzle panel. The lesson panel will be addressed later.