### PR TITLE
Disable reset in PuzzlesPanel when progress is 0

### DIFF
--- a/lib/pychess/Utils/const.py
+++ b/lib/pychess/Utils/const.py
@@ -231,5 +231,8 @@ MENU_ITEMS = GAME_MENU_ITEMS + ACTION_MENU_ITEMS + VIEW_MENU_ITEMS + EDIT_MENU_I
 # Column name
 COLUMN_ROW_RESET = "column_row_reset"
 
+# Gtk icon name
+GTK_ICON_VIEW_REFRESH = "view-refresh"
+
 # Learn categories
 LECTURE, LESSON, PUZZLE, ENDGAME = range(4)

--- a/lib/pychess/perspectives/learn/PuzzlesPanel.py
+++ b/lib/pychess/perspectives/learn/PuzzlesPanel.py
@@ -6,7 +6,8 @@ from gi.repository import Gtk
 from pychess.compat import create_task
 from pychess.System.prefix import addDataPrefix
 from pychess.Utils.const import WHITE, BLACK, LOCAL, NORMALCHESS, ARTIFICIAL, \
-    WAITING_TO_START, HINT, PRACTICE_GOAL_REACHED, PUZZLE, COLUMN_ROW_RESET
+    WAITING_TO_START, HINT, PRACTICE_GOAL_REACHED, PUZZLE, COLUMN_ROW_RESET, \
+    GTK_ICON_VIEW_REFRESH
 from pychess.Utils.LearnModel import LearnModel
 from pychess.Utils.TimeModel import TimeModel
 from pychess.Variants import variants
@@ -70,8 +71,8 @@ class Sidepanel():
         column.set_expand(True)
         self.tv.append_column(column)
 
-        renderer = Gtk.CellRendererPixbuf(stock_id=Gtk.STOCK_REFRESH)
-        column = Gtk.TreeViewColumn(_("Reset"), renderer)
+        renderer = Gtk.CellRendererPixbuf()
+        column = Gtk.TreeViewColumn(_("Reset"), renderer, icon_name=5)
         column.set_name(COLUMN_ROW_RESET)
         self.tv.append_column(column)
 
@@ -80,20 +81,21 @@ class Sidepanel():
         def on_progress_updated(solving_progress, key, progress):
             for i, row in enumerate(self.store):
                 if row[0] == key:
-                    progress_ratio_string, percent = self._compute_progress_info(progress)
+                    progress_ratio_string, percent, reset_icon = self._compute_progress_info(progress)
                     treeiter = self.store.get_iter(Gtk.TreePath(i))
                     self.store[treeiter][3] = progress_ratio_string
                     self.store[treeiter][4] = percent
+                    self.store[treeiter][5] = reset_icon
         puzzles_solving_progress.connect("progress_updated", on_progress_updated)
 
-        self.store = Gtk.ListStore(str, str, str, str, int)
+        self.store = Gtk.ListStore(str, str, str, str, int, str)
 
         @asyncio.coroutine
         def coro():
             for file_name, title, author in PUZZLES:
                 progress = puzzles_solving_progress.get(file_name)
-                progress_ratio_string, percent = self._compute_progress_info(progress)
-                self.store.append([file_name, title, author, progress_ratio_string, percent])
+                progress_ratio_string, percent, reset_icon = self._compute_progress_info(progress)
+                self.store.append([file_name, title, author, progress_ratio_string, percent, reset_icon])
                 yield from asyncio.sleep(0)
         create_task(coro())
 
@@ -123,22 +125,25 @@ class Sidepanel():
                 learn_tasker.learn_combo.set_active(path[0])
                 start_puzzle_from(filename)
 
-    def _compute_progress_info(self, progress):
+    @staticmethod
+    def _compute_progress_info(progress):
         solved = progress.count(1)
-        percent = 0 if not solved else round((solved * 100.) / len(progress))
-        return "%s / %s" % (solved, len(progress)), percent
-
+        percent = 0 if solved == 0 else round((solved * 100.) / len(progress))
+        reset_icon = None if solved == 0 else GTK_ICON_VIEW_REFRESH
+        return "%s / %s" % (solved, len(progress)), percent, reset_icon
 
     def _reset_progress_file(self, filename, title):
-        dialog = Gtk.MessageDialog(mainwindow(), 0, Gtk.MessageType.QUESTION,
-                                   Gtk.ButtonsType.OK_CANCEL,
-                                   _("This will set the progress to 0 for the puzzle") + ' "' + title + '".')
-        response = dialog.run()
-        if response == Gtk.ResponseType.OK:
-            progress = puzzles_solving_progress[filename]
-            puzzles_solving_progress[filename] = [0] * len(progress)
-            self.persp.update_progress(None, None, None)
-        dialog.destroy()
+        progress = puzzles_solving_progress[filename]
+        _str, _percent, reset_icon = self._compute_progress_info(progress)
+        if reset_icon is not None:
+            dialog = Gtk.MessageDialog(mainwindow(), 0, Gtk.MessageType.QUESTION,
+                                       Gtk.ButtonsType.OK_CANCEL,
+                                       _('This will reset the progress to 0 for the puzzle "{title}"').format(title))
+            response = dialog.run()
+            if response == Gtk.ResponseType.OK:
+                puzzles_solving_progress[filename] = [0] * len(progress)
+                self.persp.update_progress(None, None, None)
+            dialog.destroy()
 
 
 def start_puzzle_from(filename, index=None):


### PR DESCRIPTION
Targets issue #1688.

To do this, I added a field to the TreeView store. The new field specifies whether or not the icon should be shown. The `_reset_progress_file` method also checks whether the icon exists before prompting the user. I had to extend the code which computes the progress, but it was duplicated, so factorized the logic into a method: `_compute_progress_info`.

This PR also does the following:

- The `stock_id` property of Pixbuf was actually deprecated so I switched to the new `icon_name` property and created the `GTK_ICON_VIEW_REFRESH` constant to hold the icon name. See (https://lazka.github.io/pgi-docs/Gtk-3.0/constants.html#Gtk.STOCK_REFRESH)
- The internationalization of the modal message did not use interpolation as it should. This is fixed in this PR.