### PR TITLE
Modern CPU

### DIFF
--- a/lib/pychess/System/cpu.py
+++ b/lib/pychess/System/cpu.py
@@ -24,7 +24,8 @@ def get_cpu():
         result['popcnt'] = 'popcnt' in info
         result['bmi2'] = 'bmi2' in info
     except OSError:
-        # TODO Windows
-        result['popcnt'] = False
-        result['bmi2'] = False
+        # Logic not fully true
+        guess = (result['bitness'] == '64')
+        result['popcnt'] = guess
+        result['bmi2'] = guess
     return result


### PR DESCRIPTION
Hello,

This PR proposes an easy fix for checking under Windows if the cpu is modern.
The check is imperfect, but it is less wrong than the current one.
You should now be proposed "stockfish_popcnt.exe" in "add engines in mass" if you have a 64-bit cpu.

HaGN