### PR TITLE
Add per-lesson reset to the Lesson panel

### DIFF
--- a/lib/pychess/perspectives/learn/LessonsPanel.py
+++ b/lib/pychess/perspectives/learn/LessonsPanel.py
@@ -1,7 +1,4 @@
 import os
-import asyncio
-
-from gi.repository import Gtk
 
 from pychess.compat import create_task
 from pychess.System.prefix import addDataPrefix
@@ -35,6 +32,7 @@ for elem in sorted(os.listdir(path=addDataPrefix("learn/lessons/"))):
         LESSONS.append((elem, elem.replace("-", " ").capitalize(), "pychess.org"))
 
 # Note: Find the declaration of the class Sidepanel at the end of the file
+
 
 def start_lesson_from(filename, index=None):
     chessfile = PGNFile(protoopen(addDataPrefix("learn/lessons/%s" % filename)))

--- a/lib/pychess/perspectives/learn/PuzzlesPanel.py
+++ b/lib/pychess/perspectives/learn/PuzzlesPanel.py
@@ -1,7 +1,4 @@
 import os
-import asyncio
-
-from gi.repository import Gtk
 
 from pychess.compat import create_task
 from pychess.System.prefix import addDataPrefix
@@ -14,13 +11,13 @@ from pychess.Variants import variants
 from pychess.Players.Human import Human
 from pychess.Players.engineNest import discoverer
 from pychess.perspectives import perspective_manager
+from pychess.perspectives.learn.generate.generateLessonsSidepanel import generateLessonsSidepanel
 from pychess.perspectives.learn import lessons_solving_progress
 from pychess.perspectives.learn import puzzles_solving_progress
 from pychess.Savers.olv import OLVFile
 from pychess.Savers.pgn import PGNFile
 from pychess.System import conf
 from pychess.System.protoopen import protoopen
-from pychess.widgets import mainwindow
 
 __title__ = _("Puzzles")
 
@@ -50,101 +47,7 @@ for elem in sorted(os.listdir(path=addDataPrefix("learn/puzzles/"))):
 
 PUZZLES = puzzles0 + puzzles1 + puzzles2 + puzzles3
 
-
-class Sidepanel():
-    def load(self, persp):
-        self.persp = persp
-        self.box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-
-        self.tv = Gtk.TreeView()
-
-        renderer = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn(_("Title"), renderer, text=1)
-        self.tv.append_column(column)
-
-        renderer = Gtk.CellRendererText()
-        column = Gtk.TreeViewColumn(_("Source"), renderer, text=2)
-        self.tv.append_column(column)
-
-        renderer = Gtk.CellRendererProgress()
-        column = Gtk.TreeViewColumn(_("Progress"), renderer, text=3, value=4)
-        column.set_expand(True)
-        self.tv.append_column(column)
-
-        renderer = Gtk.CellRendererPixbuf()
-        column = Gtk.TreeViewColumn(_("Reset"), renderer, icon_name=5)
-        column.set_name(COLUMN_ROW_RESET)
-        self.tv.append_column(column)
-
-        self.tv.connect("row-activated", self.row_activated)
-
-        def on_progress_updated(solving_progress, key, progress):
-            for i, row in enumerate(self.store):
-                if row[0] == key:
-                    progress_ratio_string, percent, reset_icon = self._compute_progress_info(progress)
-                    treeiter = self.store.get_iter(Gtk.TreePath(i))
-                    self.store[treeiter][3] = progress_ratio_string
-                    self.store[treeiter][4] = percent
-                    self.store[treeiter][5] = reset_icon
-        puzzles_solving_progress.connect("progress_updated", on_progress_updated)
-
-        self.store = Gtk.ListStore(str, str, str, str, int, str)
-
-        @asyncio.coroutine
-        def coro():
-            for file_name, title, author in PUZZLES:
-                progress = puzzles_solving_progress.get(file_name)
-                progress_ratio_string, percent, reset_icon = self._compute_progress_info(progress)
-                self.store.append([file_name, title, author, progress_ratio_string, percent, reset_icon])
-                yield from asyncio.sleep(0)
-        create_task(coro())
-
-        self.tv.set_model(self.store)
-        self.tv.get_selection().set_mode(Gtk.SelectionMode.BROWSE)
-        self.tv.set_cursor(conf.get("learncombo%s" % PUZZLE))
-
-        scrollwin = Gtk.ScrolledWindow()
-        scrollwin.add(self.tv)
-        scrollwin.show_all()
-
-        self.box.pack_start(scrollwin, True, True, 0)
-        self.box.show_all()
-
-        return self.box
-
-    def row_activated(self, widget, path, col):
-        if path is None:
-            return
-        else:
-            filename, title, *_ = PUZZLES[path[0]]
-            if col.get_name() == COLUMN_ROW_RESET:
-                self._reset_progress_file(filename, title)
-            else:
-                conf.set("categorycombo", PUZZLE)
-                from pychess.widgets.TaskerManager import learn_tasker
-                learn_tasker.learn_combo.set_active(path[0])
-                start_puzzle_from(filename)
-
-    @staticmethod
-    def _compute_progress_info(progress):
-        solved = progress.count(1)
-        percent = 0 if solved == 0 else round((solved * 100.) / len(progress))
-        reset_icon = None if solved == 0 else GTK_ICON_VIEW_REFRESH
-        return "%s / %s" % (solved, len(progress)), percent, reset_icon
-
-    def _reset_progress_file(self, filename, title):
-        progress = puzzles_solving_progress[filename]
-        _str, _percent, reset_icon = self._compute_progress_info(progress)
-        if reset_icon is not None:
-            dialog = Gtk.MessageDialog(mainwindow(), 0, Gtk.MessageType.QUESTION,
-                                       Gtk.ButtonsType.OK_CANCEL,
-                                       _('This will reset the progress to 0 for the puzzle "{title}"').format(title=title))
-            response = dialog.run()
-            if response == Gtk.ResponseType.OK:
-                puzzles_solving_progress[filename] = [0] * len(progress)
-                self.persp.update_progress(None, None, None)
-            dialog.destroy()
-
+# Note: Find the declaration of the class Sidepanel at the end of the file
 
 def start_puzzle_from(filename, index=None):
     if filename.lower().endswith(".pgn"):
@@ -230,3 +133,12 @@ def start_puzzle_game(gamemodel, filename, records, index, rec, from_lesson=Fals
 
     perspective = perspective_manager.get_perspective("games")
     create_task(perspective.generalStart(gamemodel, p0, p1))
+
+
+# Sidepanel is a class
+Sidepanel = generateLessonsSidepanel(
+    solving_progress=puzzles_solving_progress,
+    learn_category_id=PUZZLE,
+    entries=PUZZLES,
+    start_from=start_puzzle_from,
+)

--- a/lib/pychess/perspectives/learn/PuzzlesPanel.py
+++ b/lib/pychess/perspectives/learn/PuzzlesPanel.py
@@ -3,8 +3,7 @@ import os
 from pychess.compat import create_task
 from pychess.System.prefix import addDataPrefix
 from pychess.Utils.const import WHITE, BLACK, LOCAL, NORMALCHESS, ARTIFICIAL, \
-    WAITING_TO_START, HINT, PRACTICE_GOAL_REACHED, PUZZLE, COLUMN_ROW_RESET, \
-    GTK_ICON_VIEW_REFRESH
+    WAITING_TO_START, HINT, PRACTICE_GOAL_REACHED, PUZZLE
 from pychess.Utils.LearnModel import LearnModel
 from pychess.Utils.TimeModel import TimeModel
 from pychess.Variants import variants
@@ -48,6 +47,7 @@ for elem in sorted(os.listdir(path=addDataPrefix("learn/puzzles/"))):
 PUZZLES = puzzles0 + puzzles1 + puzzles2 + puzzles3
 
 # Note: Find the declaration of the class Sidepanel at the end of the file
+
 
 def start_puzzle_from(filename, index=None):
     if filename.lower().endswith(".pgn"):

--- a/lib/pychess/perspectives/learn/generate/generateLessonsSidepanel.py
+++ b/lib/pychess/perspectives/learn/generate/generateLessonsSidepanel.py
@@ -1,0 +1,115 @@
+import asyncio
+
+from gi.repository import Gtk
+
+from pychess.compat import create_task
+from pychess.System import conf
+from pychess.Utils.const import COLUMN_ROW_RESET, GTK_ICON_VIEW_REFRESH
+from pychess.widgets import mainwindow
+
+
+def generateLessonsSidepanel(solving_progress, learn_category_id, entries, start_from):
+    """
+    generateLessonsSidepanel returns a class to be used as a panel by Gtk. More
+    specifically, that class is meant to be named Sidepanel.
+
+    generateLessonsSidepanel allows to avoid duplicate code between
+    PuzzlesPanel and LessonsPanel.py.
+    """
+    class Sidepanel():
+        def load(self, persp):
+            self.persp = persp
+            self.box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+
+            self.tv = Gtk.TreeView()
+
+            renderer = Gtk.CellRendererText()
+            column = Gtk.TreeViewColumn(_("Title"), renderer, text=1)
+            self.tv.append_column(column)
+
+            renderer = Gtk.CellRendererText()
+            column = Gtk.TreeViewColumn(_("Source"), renderer, text=2)
+            self.tv.append_column(column)
+
+            renderer = Gtk.CellRendererProgress()
+            column = Gtk.TreeViewColumn(_("Progress"), renderer, text=3, value=4)
+            column.set_expand(True)
+            self.tv.append_column(column)
+
+            renderer = Gtk.CellRendererPixbuf()
+            column = Gtk.TreeViewColumn(_("Reset"), renderer, icon_name=5)
+            column.set_name(COLUMN_ROW_RESET)
+            self.tv.append_column(column)
+
+            self.tv.connect("row-activated", self.row_activated)
+
+            def on_progress_updated(solving_progress, key, progress):
+                for i, row in enumerate(self.store):
+                    if row[0] == key:
+                        progress_ratio_string, percent, reset_icon = self._compute_progress_info(progress)
+                        treeiter = self.store.get_iter(Gtk.TreePath(i))
+                        self.store[treeiter][3] = progress_ratio_string
+                        self.store[treeiter][4] = percent
+                        self.store[treeiter][5] = reset_icon
+            solving_progress.connect("progress_updated", on_progress_updated)
+
+            self.store = Gtk.ListStore(str, str, str, str, int, str)
+
+            @asyncio.coroutine
+            def coro():
+                for file_name, title, author in entries:
+                    progress = solving_progress.get(file_name)
+                    progress_ratio_string, percent, reset_icon = self._compute_progress_info(progress)
+                    self.store.append([file_name, title, author, progress_ratio_string, percent, reset_icon])
+                    yield from asyncio.sleep(0)
+            create_task(coro())
+
+            self.tv.set_model(self.store)
+            self.tv.get_selection().set_mode(Gtk.SelectionMode.BROWSE)
+            self.tv.set_cursor(conf.get("learncombo%s" % learn_category_id))
+
+            scrollwin = Gtk.ScrolledWindow()
+            scrollwin.add(self.tv)
+            scrollwin.show_all()
+
+            self.box.pack_start(scrollwin, True, True, 0)
+            self.box.show_all()
+
+            return self.box
+
+        def row_activated(self, widget, path, col):
+            if path is None:
+                return
+            else:
+                filename, title, *_ = entries[path[0]]
+                if col.get_name() == COLUMN_ROW_RESET:
+                    self._reset_progress_file(filename, title)
+                else:
+                    conf.set("categorycombo", learn_category_id)
+                    from pychess.widgets.TaskerManager import learn_tasker
+                    learn_tasker.learn_combo.set_active(path[0])
+                    start_from(filename)
+
+        @staticmethod
+        def _compute_progress_info(progress):
+            solved = progress.count(1)
+            percent = 0 if solved == 0 else round((solved * 100.) / len(progress))
+            reset_icon = None if solved == 0 else GTK_ICON_VIEW_REFRESH
+            return "%s / %s" % (solved, len(progress)), percent, reset_icon
+
+        def _reset_progress_file(self, filename, title):
+            progress = solving_progress[filename]
+            _str, _percent, reset_icon = self._compute_progress_info(progress)
+            if reset_icon is not None:
+                dialog = Gtk.MessageDialog(
+                    mainwindow(), 0,
+                    Gtk.MessageType.QUESTION,
+                    Gtk.ButtonsType.OK_CANCEL,
+                    _('This will reset the progress to 0 for the puzzle "{title}"').format(title=title),
+                )
+                response = dialog.run()
+                if response == Gtk.ResponseType.OK:
+                    solving_progress[filename] = [0] * len(progress)
+                    self.persp.update_progress(None, None, None)
+                dialog.destroy()
+    return Sidepanel


### PR DESCRIPTION
Targets #1688. The pull request removes duplicated code in the Sidepanel classes of LessonsPanel.py
and PuzzlesPanel.py, by putting it in a function, in its own file:
generate/generateLessonsSidepanel.py.
As a side-effect, the lesson panel gets the same features as the puzzle panel, getting a reset button column.