### PR TITLE
Remove use of deprecated configparser.readfp() for read_file()

### DIFF
--- a/lib/pychess/System/conf.py
+++ b/lib/pychess/System/conf.py
@@ -24,7 +24,7 @@ path = addUserConfigPrefix("config")
 encoding = locale.getpreferredencoding()
 if os.path.isfile(path):
     with open(path, encoding=encoding) as fh:
-        configParser.readfp(fh)
+        configParser.read_file(fh)
 
 
 def save_config(path=path, encoding=encoding):


### PR DESCRIPTION
Hello,

Should be the last clean-up patch :)
[readfp()](https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.readfp) is deprecated since Python 3.2.

Signed-off-by: Mickaël Schoentgen <contact@tiger-222.fr>