### PR TITLE
Allow linux executables in new engine dialog

### DIFF
--- a/lib/pychess/widgets/enginesDialog.py
+++ b/lib/pychess/widgets/enginesDialog.py
@@ -192,6 +192,7 @@ class EnginesDialog():
         filter.add_mime_type("application/x-sharedlib")
         filter.add_mime_type("application/x-ms-dos-executable")
         filter.add_mime_type("application/x-msdownload")
+        filter.add_mime_type("application/x-sharedlib")
         filter.add_pattern("*.exe")
         for vm in VM_LIST:
             filter.add_pattern("*%s" % vm.ext)

--- a/lib/pychess/widgets/enginesDialog.py
+++ b/lib/pychess/widgets/enginesDialog.py
@@ -198,6 +198,10 @@ class EnginesDialog():
             filter.add_pattern("*%s" % vm.ext)
 
         engine_chooser_dialog.add_filter(filter)
+        filter = Gtk.FileFilter()
+        filter.set_name(_("All Files"))
+        filter.add_pattern("*")
+        engine_chooser_dialog.add_filter(filter)
         self.add = False
 
         def add(button):


### PR DESCRIPTION
Fixes #1901 

Adds the mimetype for linux executables to allow you to add new chess engines on linux.

Also adds a second file filter for "All Files" (which is usually good HIG guidelines anyway) in case users have executables with some other mimetypes as well.