### PR TITLE
Remove the nonexsiting 'Pychess' theme from themes. Fixes #1907

### DIFF
--- a/lib/pychess/widgets/preferencesDialog.py
+++ b/lib/pychess/widgets/preferencesDialog.py
@@ -797,7 +797,7 @@ class ThemeTab:
 
             :return: (a List) of themes
         """
-        themes = ['Pychess']
+        themes = []
 
         pieces = addDataPrefix("pieces")
         themes += [d.capitalize()


### PR DESCRIPTION
The discoverThemes() adds a 'Pychess' theme by defualt this causes the loop that displays the themes in Preferences->themes tab to terminate prematurely and leave out any theme that comes after 'Pychess' alphabetically.
See issue #1907