### PR TITLE
Add the new optional `msg` parameter to `cancel` method of the class pychess.Util.wait_signal

### DIFF
--- a/lib/pychess/Utils/__init__.py
+++ b/lib/pychess/Utils/__init__.py
@@ -83,11 +83,11 @@ class wait_signal(asyncio.Future):
             obj.disconnect(self._hnd)
         self.set_result(k)
 
-    def cancel(self):
+    def cancel(self, msg=None):
         if self.cancelled():
             return False
         try:
-            super().cancel()
+            super().cancel(msg=msg)
         except AttributeError:
             pass
         try:


### PR DESCRIPTION
Since python 3.9, the `cancel` method of Futures has
an added optional `msg=None` parameter:
https://docs.python.org/3/library/asyncio-future.html#asyncio.Future.cancel

See issue #1918
After adding this optional parameter, the `TypeError` goes away.