### PR TITLE
Same fix as commit e6091ea11 applied to create_theme_preview.py

### DIFF
--- a/create_theme_preview.py
+++ b/create_theme_preview.py
@@ -3,6 +3,8 @@ import os
 from os import listdir
 from os.path import isdir, isfile, splitext
 
+import gi
+gi.require_version('Gtk', '3.0')
 from gi.repository import Gtk
 import cairo
 


### PR DESCRIPTION
silence pygi warning requiring gtk 3.0