### PR TITLE
Limit analysis depth to 99

### DIFF
--- a/glade/PyChess.glade
+++ b/glade/PyChess.glade
@@ -2099,7 +2099,7 @@ It will search positions from http://www.k4it.de/</property>
                                       <object class="GtkSpinButton" id="max_depth_spin">
                                         <property name="visible">True</property>
                                         <property name="can-focus">True</property>
-                                        <property name="max-length">4</property>
+                                        <property name="max-length">2</property>
                                         <property name="invisible-char">●</property>
                                         <property name="primary-icon-activatable">False</property>
                                         <property name="secondary-icon-activatable">False</property>


### PR DESCRIPTION
I limited the Glade element to only allow for 2 digits, thus limiting the analysis depth to 99.

Issue #1940 