### PR TITLE
Improve MacOS compatibility - this is working for me with MacOS 12.0.1

### DIFF
--- a/INSTALL_MACOS
+++ b/INSTALL_MACOS
@@ -1,6 +1,6 @@
 Install the following binary dependencies:
 
-brew install gtk+3 pygobject3 gtksourceview3 librsvg
+brew install gtk+3 pygobject3 gtksourceview3 librsvg gst-python
 
 
 And then install the python depdencies:

--- a/INSTALL_MACOS
+++ b/INSTALL_MACOS
@@ -1,0 +1,8 @@
+Install the following binary dependencies:
+
+brew install gtk+3 pygobject3 gtksourceview3 librsvg
+
+
+And then install the python depdencies:
+
+pip install -r req.txt

--- a/pychess
+++ b/pychess
@@ -185,8 +185,13 @@ else:
         libintl.bind_textdomain_codeset(domain, 'UTF-8')
     elif sys.platform == 'darwin':
         import ctypes
-        libintl = ctypes.cdll.LoadLibrary('libintl.dylib')
+        try:
+            libintl = ctypes.cdll.LoadLibrary('libintl.dylib')
+        except OSError:
+            # This is default install location if using brew to install dependencies
+            libintl = ctypes.cdll.LoadLibrary('/usr/local/lib/libintl.dylib')
         libintl.bindtextdomain(domain, locale_dir)
+
     else:
         locale.bindtextdomain(domain, locale_dir)
 


### PR DESCRIPTION
When using brew to install the depdencies, libraries are placed in /usr/local/lib

Apple's security prevents us from using DYLD_FALLBACK_LIBRARY_PATH so we add a simple second attempt to load frmo /usr/local/lib on darwin.

Also added a small doc file on how to install on MacOS.

Fixes #1757 