### PR TITLE
requirements(deps): bump importlib-metadata from 1.6.0 to 6.0.0 + pin new indirect dependencies (alternative to #1966)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 attrs==22.2.0
-importlib-metadata==1.6.0
+importlib-metadata==6.0.0
 more-itertools==8.2.0
 packaging==23.0
 pexpect==4.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pyparsing==3.0.9
 pytest==5.4.2
 six==1.14.0
 SQLAlchemy==1.3.17
+typing_extensions==4.5.0
 wcwidth==0.2.6
 websockets==10.4
 zipp==3.1.0


### PR DESCRIPTION
Going further with #1966 to get dependencies back to fully pinned and a green CI.