### PR TITLE
 requirements(deps): bump pytest from 5.4.2 to 7.2.2 + pin new indirect dependencies (alternative to #1978)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ PyGObject==3.42.2
 PyOgg==0.6.14a1
 PyOpenAL==0.7.11a1
 pyparsing==3.0.9
-pytest==5.4.2
+pytest==7.2.2
 six==1.14.0
 SQLAlchemy==1.3.17
 typing_extensions==4.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 attrs==22.2.0
+exceptiongroup==1.1.0
 importlib-metadata==6.0.0
+iniconfig==2.0.0
 more-itertools==8.2.0
 packaging==23.0
 pexpect==4.8.0
@@ -15,6 +17,7 @@ pyparsing==3.0.9
 pytest==7.2.2
 six==1.14.0
 SQLAlchemy==1.3.17
+tomli==2.0.1
 typing_extensions==4.5.0
 wcwidth==0.2.6
 websockets==10.4


### PR DESCRIPTION
Alternative to #1978

This builds on top of #1978 but also pins the new indirect dependencies that were proven missing at https://github.com/pychess/pychess/actions/runs/4384798067/jobs/7676704521#step:5:182 .