### PR TITLE
Make PerspectiveManager.on_persp_toggled more robust

### DIFF
--- a/lib/pychess/perspectives/__init__.py
+++ b/lib/pychess/perspectives/__init__.py
@@ -165,10 +165,11 @@ class PerspectiveManager:
     def on_persp_toggled(self, button):
         active = button.get_active()
         if active:
-            for item in self.current_perspective.menuitems:
-                item.hide()
-            for toolbutton in self.current_perspective.toolbuttons:
-                toolbutton.hide()
+            if self.current_perspective is not None:
+                for item in self.current_perspective.menuitems:
+                    item.hide()
+                for toolbutton in self.current_perspective.toolbuttons:
+                    toolbutton.hide()
 
             name = button.get_name()
             perspective, button, index = self.perspectives[name]


### PR DESCRIPTION
Attribute `current_perspective` can be `None` before it is set a few lines below, for the first time.

PS: Can be seen triggered by current CI e.g. at https://github.com/pychess/pychess/actions/runs/4379761622/jobs/7666065791#step:6:69 .
