### PR TITLE
[draft] Make GitHub Actions build a .msi file using cx_Freeze and MSYS

### DIFF
--- a/.github/workflows/windows-build-msys.yml
+++ b/.github/workflows/windows-build-msys.yml
@@ -1,0 +1,54 @@
+# Copyright (C) 2023 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GPL v3 or later
+
+name: Build for Windows
+
+# Drop permissions to minimum for security
+permissions:
+  contents: read
+
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 2 * * 5'  # Every Friday at 2am
+
+jobs:
+  checks:
+    name: Build for Windows
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install build dependencies
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        install: |
+          mingw-w64-x86_64-gtk3
+          mingw-w64-x86_64-gtksourceview3
+          mingw-w64-x86_64-python
+          mingw-w64-x86_64-python-cairo
+          mingw-w64-x86_64-python-cx_Freeze
+          mingw-w64-x86_64-python-gobject
+          mingw-w64-x86_64-python-pexpect
+          mingw-w64-x86_64-python-psutil
+          mingw-w64-x86_64-python-sqlalchemy
+
+    - name: Build
+      run: |-
+        set -x
+        PYTHONPATH=lib python3 pgn2ecodb.py
+        PYTHONPATH=lib python3 create_theme_preview.py
+        python3 setup.py bdist_msi --help
+        python3 setup.py bdist_msi
+
+    - name: Store Windows binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: pychess_win64_msi_${{ github.sha }}
+        path: dist/*.msi
+        if-no-files-found: error

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ sys.path = [os.path.join(this_dir, "lib")] + sys.path
 
 
 msi = False
-if sys.argv[-1] == "bdist_msi":
+if "bdist_msi" in sys.argv[1:]:
     try:
         from cx_Freeze import setup, Executable
         msi = True

--- a/setup.py
+++ b/setup.py
@@ -234,7 +234,7 @@ if msi:
     for mo in gtk_mo:
         mofile = os.path.join(lang_path, mo)
         if os.path.isfile(mofile):
-            include_files.append("share/locale/" + mo)
+            include_files.append(os.path.join(lang_path, mo))
 
     for dll in gtk_exec:
         include_files.append(os.path.join(gtk_exec_path, dll))

--- a/setup.py
+++ b/setup.py
@@ -234,14 +234,14 @@ if msi:
     for mo in gtk_mo:
         mofile = os.path.join(lang_path, mo)
         if os.path.isfile(mofile):
-            include_files.append((mofile, "share/locale/" + mo))
+            include_files.append("share/locale/" + mo)
 
     for dll in gtk_exec:
-        include_files.append((os.path.join(gtk_exec_path, dll), dll))
+        include_files.append(os.path.join(gtk_exec_path, dll))
 
     # Let's add gtk data
     for lib in gtk_data:
-        include_files.append((os.path.join(gtk_data_path, lib), lib))
+        include_files.append(os.path.join(gtk_data_path, lib))
 
     base = None
     # Lets not open the console while running the app

--- a/setup.py
+++ b/setup.py
@@ -251,10 +251,10 @@ if msi:
     executables = [Executable("pychess",
                               base=base,
                               icon="pychess.ico",
-                              shortcutName="PyChess",
-                              shortcutDir="DesktopFolder"),
+                              shortcut_name="PyChess",
+                              shortcut_dir="DesktopFolder"),
                    Executable(script="lib/__main__.py",
-                              targetName="pychess-engine.exe",
+                              target_name="pychess-engine.exe",
                               base=base)]
 
     bdist_msi_options = {

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ msi = False
 if sys.argv[-1] == "bdist_msi":
     try:
         from cx_Freeze import setup, Executable
-        from cx_Freeze.windist import bdist_msi
         msi = True
     except ImportError:
         print("ERROR: can't import cx_Freeze!")


### PR DESCRIPTION
Hi! :wave: 

This is inspired by earlier work in file [`appveyor.yml`](https://github.com/pychess/pychess/blob/master/appveyor.yml). It's about automated creation of `.msi` installer files for Windows users.

Please note that:
- MSYS package `mingw-w64-x86_64-python-sqlalchemy` is SQLalchemy **2**.0.x so this will not work in practice before [branch `sqlalchemy2`](https://github.com/pychess/pychess/tree/sqlalchemy2) is merged.
- I have not tried the resulting `.msi` and my access to true Windows is limited.
- This may not be complete, e.g. zlib, freetype, websockets may or may not need to be added.
- All these are reasons why it's currently marked as a draft.

On a more positive note:
- This produces ~50 MiB `.msi` file output with cx_Freeze using MSYS MinGW packages in GitHub Actions and makes them available for download from the CI run job page.
- What we have here can be built upon.

I'm in no rush with getting this merged. I am looking forward to your testing and review on and/or off GitHub :beers: 

Best, Sebastian