### PR TITLE
Make GitHub Actions build on Linux every week

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,8 +8,10 @@ permissions:
   contents: read
 
 on:
-- pull_request
-- push
+  pull_request:
+  push:
+  schedule:
+    - cron: '0 2 * * 5'  # Every Friday at 2am
 
 jobs:
   run-tests:


### PR DESCRIPTION
This would trigger every week even when there are no new pull requests and no new commits on master. The idea is that because the ground below us is moving in CI — not all of it and not crazy fast but it is moving —, it's good to see if that motion has broken things in the mean time so we can react in a few days and not only learn when e.g. a new pull request is all red from something totally unrelated.

This weekly activatation — "cron" — is already happening for the Windows CI…

https://github.com/pychess/pychess/blob/a291deb7f08f86c1a990ad7de7d4493fa6c49722/.github/workflows/windows-build-msys.yml#L10-L14

…so things will get us covered more consistently.