### PR TITLE
Fixed issue when user's home directory is in prefix during installation

### DIFF
--- a/lib/pychess/System/prefix.py
+++ b/lib/pychess/System/prefix.py
@@ -16,7 +16,7 @@ if getattr(sys, "frozen", False):
     _installed = True
 else:
     home_local = os.path.expanduser("~") + "/.local"
-    if sys.prefix in __file__:
+    if sys.prefix in __file__ and not sys.prefix in home_local:
         for sub in (
             "share",
             "games",


### PR DESCRIPTION
This occurs during build under ALT Linux. On the build system, ~ expands to /etc/src. And the package building breaks