### PR TITLE
Drop unused dependencies + improve requirements.txt + improve setup.py

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -50,7 +50,7 @@ jobs:
 
         pip3 install -U pip setuptools wheel
         pip3 install -r requirements.txt
-        diff -u0 requirements.txt <(pip3 freeze)  # enforces complete pinning
+        diff -u0 <(sed -e 's,#.*,,' -e '/^$/d' < requirements.txt | sort -f) <(pip3 freeze | sort -f)  # enforces complete pinning
 
         time PYTHONPATH=lib python3 pgn2ecodb.py
         time PYTHONPATH=lib python3 create_theme_preview.py

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -96,7 +96,7 @@ jobs:
 
         pip3 install -U pip setuptools wheel
         pip3 install -r requirements.txt
-        diff -u0 requirements.txt <(pip3 freeze)  # enforces complete pinning
+        diff -u0 <(sed -e 's,#.*,,' -e '/^$/d' < requirements.txt | sort -f) <(pip3 freeze | sort -f)  # enforces complete pinning
 
         time PYTHONPATH=lib python3 pgn2ecodb.py
         time PYTHONPATH=lib python3 create_theme_preview.py

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
         pip3 install -U pip setuptools wheel
         pip3 install -r requirements.txt
-        diff -u0 requirements.txt <(pip3 freeze)  # enforces complete pinning
+        diff -u0 <(sed -e 's,#.*,,' -e '/^$/d' < requirements.txt | sort -f) <(pip3 freeze | sort -f)  # enforces complete pinning
 
         time PYTHONPATH=lib python3 pgn2ecodb.py
         time PYTHONPATH=lib python3 create_theme_preview.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,15 @@ websockets==11.0.1
 
 # Test-only dependencies
 pytest==7.3.1
+
+# Indirect dependencies
+exceptiongroup==1.1.1
+greenlet==2.0.2
+importlib-metadata==6.4.1
+iniconfig==2.0.0
+packaging==23.1
+pluggy==1.0.0
+ptyprocess==0.7.0
+tomli==2.0.1
+typing_extensions==4.5.0
+zipp==3.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,11 @@
-attrs==23.1.0
-exceptiongroup==1.1.1
+# Direct dependencies
 gbulb==0.6.4
-greenlet==2.0.2
-importlib-metadata==6.4.1
-iniconfig==2.0.0
-more-itertools==9.1.0
-packaging==23.1
 pexpect==4.8.0
-pluggy==1.0.0
 psutil==5.9.4
-ptyprocess==0.7.0
 pycairo==1.23.0
 PyGObject==3.44.1
-PyOgg==0.6.14a1
-PyOpenAL==0.7.11a1
-pyparsing==3.0.9
-pytest==7.3.1
-six==1.16.0
 SQLAlchemy==2.0.9
-tomli==2.0.1
-typing_extensions==4.5.0
-wcwidth==0.2.6
 websockets==11.0.1
-zipp==3.15.0
+
+# Test-only dependencies
+pytest==7.3.1

--- a/setup.py
+++ b/setup.py
@@ -380,6 +380,20 @@ setup(
     license="GPL3",
     url="https://pychess.github.io/",
     download_url="https://github.com/pychess/pychess/releases",
+    python_requires=">=3.7",
+    install_requires=[
+        "pexpect",
+        "psutil",
+        "pycairo",
+        "PyGObject",
+        "SQLAlchemy>=2",
+        "websockets",
+    ],
+    extras_require={
+        "gbulb": [
+            "gbulb",
+        ],
+    },
     package_dir={"": "lib"},
     packages=PACKAGES,
     data_files=DATA_FILES,


### PR DESCRIPTION
:point_right:  If this gets merged, it would be nice to not squash-merge the commit separation away. :point_left: 

This pull request:
- Adds missing `*_requires` keys to `setup.py`.
- Drops unused dependencies.
- Classifies and groups dependencies in `requirements.txt`..

My analysis regarding dependencies was this:

```
runtime always
    pexpect==4.8.0
    psutil==5.9.4
    pycairo==1.23.0
    PyGObject==3.44.1
    SQLAlchemy==2.0.9
    websockets==11.0.1
    
runtime optional
    gbulb==0.6.4

test-only
    pytest==7.3.1

indirect dependencies
    exceptiongroup==1.1.1
    greenlet==2.0.2
    importlib-metadata==6.4.1
    iniconfig==2.0.0
    packaging==23.1
    pluggy==1.0.0
    ptyprocess==0.7.0
    tomli==2.0.1
    typing_extensions==4.5.0
    zipp==3.15.0

neither direct nor indirect
    attrs==23.1.0
    more-itertools==9.1.0
    PyOgg==0.6.14a1
    PyOpenAL==0.7.11a1
    pyparsing==3.0.9
    six==1.16.0
    wcwidth==0.2.6
```

Note that audio playback seems to be all handled by gstreamer, not OpenAL, not PyOgg.  Does that sound correct?
