### PR TITLE
CI: Pin all GitHub Actions to specific commits for security

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build DEB package for Linux
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
     - name: Install dependencies
       run: |
@@ -66,7 +66,7 @@ jobs:
         rm -Rf deb_dist/pychess-*/
 
     - name: Store DEB artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: pychess_deb_${{ github.sha }}
         path: deb_dist/

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -23,7 +23,7 @@ jobs:
     env:
       PYVER: ${{ matrix.python-version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
     - name: Install dependencies
       run: |
@@ -111,7 +111,7 @@ jobs:
         bash -x "create_rpm_py${PYVER/./}.sh"
 
     - name: Store RPM artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: pychess_rpm_py${{ matrix.python-version }}_${{ github.sha }}
         path: dist/

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,8 +18,8 @@ jobs:
     name: Run pre-commit
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
       with:
         python-version: 3.11
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@646c83fcd040023954eafda54b4db0192ce70507  # v3.0.0

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -21,9 +21,9 @@ jobs:
         python-version: [3.7, 3.11]  # no particular need for in-between versions
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435  # v4.5.0
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/windows-build-msys.yml
+++ b/.github/workflows/windows-build-msys.yml
@@ -21,10 +21,10 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab  # v3.5.2
 
     - name: Install build dependencies (MSYS)
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff  # v2
       with:
         update: true
         msystem: MINGW64
@@ -47,7 +47,7 @@ jobs:
         pip3 install websockets
 
     - name: Install build dependencies (Stockfish)
-      uses: robinraju/release-downloader@v1.7
+      uses: robinraju/release-downloader@768b85c8d69164800db5fc00337ab917daf3ce68  # v1.7
       with:
         repository: fairy-stockfish/Fairy-Stockfish
         latest: true
@@ -63,7 +63,7 @@ jobs:
         python3 setup.py bdist_msi
 
     - name: Store Windows binaries
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce  # v3.1.2
       with:
         name: pychess_win64_msi_${{ github.sha }}
         path: dist/*.msi


### PR DESCRIPTION
For proof that GitHub Dependabot can still keep things up to date for us with the new format see https://github.com/gentoo-ev/www.gentoo-ev.org/pull/5/files .