### PR TITLE
Disable engine auto detection for 'spike'

### DIFF
--- a/lib/pychess/Players/engineList.py
+++ b/lib/pychess/Players/engineList.py
@@ -111,7 +111,7 @@ ENGINES_LIST = [
     ENGINE("bobcat", "uci", "nl", 3057, AUTO_DETECT, None),
     ENGINE("amoeba", "uci", "fr", 3102, AUTO_DETECT, None),
     ENGINE("smarthink", "uci", "ru", 3043, AUTO_DETECT, None),  # Allows XB
-    ENGINE("spike", "uci", "de", 3040, AUTO_DETECT, None),  # Allows XB
+    ENGINE("spike", "uci", "de", 3040, NO_AUTO_DETECT, None),  # Allows XB
     ENGINE("alfil", "uci", "es", 3031, AUTO_DETECT, None),
     ENGINE("igel", "uci", "ch", 3187, NO_AUTO_DETECT, None),
     ENGINE("minic", "xboard", "fr", 3138, NO_AUTO_DETECT, None),


### PR DESCRIPTION
**spike** is an [unrelated software in Archlinux](https://github.com/riscv-software-src/riscv-isa-sim) repository. I searched for **spike** in Debian, Ubuntu and Fedora package indexes, and they also don't package the [spike chess engine](http://spike.lazypics.de/index_en.html).
So I think if the user is going to install the spike engine manually they would also add it to pychess themselves.

See [this comment](https://gitlab.archlinux.org/archlinux/packaging/packages/pychess/-/blob/1.0.4-3/PKGBUILD?ref_type=tags#L16) from the Archlinux pychess packager. pychess mistakes `/usr/bin/spike` for a chess engine.