### PR TITLE
Set alignment to the right for numeric values in game list treeview

### DIFF
--- a/lib/pychess/perspectives/database/gamelist.py
+++ b/lib/pychess/perspectives/database/gamelist.py
@@ -89,6 +89,8 @@ class GameList(Gtk.TreeView):
 
         for i, title in enumerate(titles):
             r = Gtk.CellRendererText()
+            if i in (0, 2, 4, 9, 10, 12):
+                r.set_alignment(1.0, 0.5) # set alignment to the right for numeric values
             column = Gtk.TreeViewColumn(title, r, text=i)
             column.set_resizable(True)
             column.set_reorderable(True)

--- a/lib/pychess/perspectives/database/gamelist.py
+++ b/lib/pychess/perspectives/database/gamelist.py
@@ -90,7 +90,9 @@ class GameList(Gtk.TreeView):
         for i, title in enumerate(titles):
             r = Gtk.CellRendererText()
             if i in (0, 2, 4, 9, 10, 12):
-                r.set_alignment(1.0, 0.5) # set alignment to the right for numeric values
+                r.set_alignment(
+                    1.0, 0.5
+                )  # set alignment to the right for numeric values
             column = Gtk.TreeViewColumn(title, r, text=i)
             column.set_resizable(True)
             column.set_reorderable(True)


### PR DESCRIPTION
This is an enhancement to the database game list TreeView : this aligns the numeric data to the right, which makes it easier to read.