### PR TITLE
`windows-build-msys.yml`: Allow upgrades to `msys2/setup-msys2` by Dependabot

### DIFF
--- a/.github/workflows/windows-build-msys.yml
+++ b/.github/workflows/windows-build-msys.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f  # v4.1.3
 
     - name: Install build dependencies (MSYS)
-      uses: msys2/setup-msys2@7efe20baefed56359985e327d329042cde2434ff  # v2
+      uses: msys2/setup-msys2@cc11e9188b693c2b100158c3322424c4cc1dadea  # v2.22.0
       with:
         update: true
         msystem: MINGW64


### PR DESCRIPTION
.. and bump from effective `v2.17.0`(?) to `v2.22.0`.

In reaction to warning…

![MSYS_Screenshot_20240425_205328](https://github.com/pychess/pychess/assets/1577132/bdab5f4f-cef7-4aa4-9cba-31e379e47a29)

…seen at https://github.com/pychess/pychess/actions/runs/8837443869 . 
