### PR TITLE
TimeSeal.py: make IAC_WONT_ECHO a literal as telnetlib is gone (#2233)

### DIFF
--- a/lib/pychess/ic/TimeSeal.py
+++ b/lib/pychess/ic/TimeSeal.py
@@ -1,6 +1,5 @@
 import asyncio
 import sys
-import telnetlib
 import random
 import time
 import platform
@@ -23,7 +22,9 @@ ENCODE = [ord(i) for i in "Timestamp (FICS) v1.0 - programmed by Henrik Gram."]
 ENCODELEN = len(ENCODE)
 G_RESPONSE = "\x029"
 FILLER = b"1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
-IAC_WONT_ECHO = b"".join([telnetlib.IAC, telnetlib.WONT, telnetlib.ECHO])
+# was: b"".join([telnetlib.IAC, telnetlib.WONT, telnetlib.ECHO])
+# but telnetlib was removed in Python 3.13
+IAC_WONT_ECHO = b"\xff\xfc\x01"
 
 _DEFAULT_LIMIT = 2**16
 


### PR DESCRIPTION
telnetlib was removed in Python 3.13. As we only used it to create a bytestring from these constants, let's just make it a literal instead.