### PR TITLE
Fix CI / `build-rpm.yml`: Ensure recent enough packaging for setuptools

### DIFF
--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -112,6 +112,9 @@ jobs:
     - name: "Build RPM package"
       run: |
         set -x -u
+        # https://github.com/pypa/setuptools/issues/4483
+        # https://github.com/pypa/packaging/commit/e99b37eae68da4016d8d015452a3c031e5d75e5d
+        sudo pip3 install -U 'packaging>=22'
         bash -x "create_rpm_py${PYVER/./}.sh"
 
     - name: Store RPM artifacts


### PR DESCRIPTION
Red CI build log:
https://github.com/pychess/pychess/actions/runs/13580358745

Issue in setuptools:
https://github.com/pypa/setuptools/issues/4483

Related commit in packaging:
https://github.com/pypa/packaging/commit/e99b37eae68da4016d8d015452a3c031e5d75e5d

CC @gbtami 