### PR TITLE
Fix task creation from non-async context (fixes #2360)

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,5 +21,5 @@ jobs:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
     - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
       with:
-        python-version: 3.12
+        python-version: 3.13
     - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.12]  # no particular need for in-between versions
+        python-version: [3.9, "3.14.0-beta.4"]  # no particular need for in-between versions
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,6 +17,7 @@ jobs:
   run-tests:
     name: Run the test suite
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.9, 3.12]  # no particular need for in-between versions
     runs-on: ubuntu-24.04

--- a/lib/pychess/Players/CECPEngine.py
+++ b/lib/pychess/Players/CECPEngine.py
@@ -171,7 +171,9 @@ class CECPEngine(ProtocolEngine):
         self.lastpong = 0
 
         self.queue = asyncio.Queue()
-        self.parse_line_task = asyncio.create_task(self.parseLine(self.engine))
+        self.parse_line_task = asyncio.get_event_loop().create_task(
+            self.parseLine(self.engine)
+        )
         self.died_cid = self.engine.connect(
             "died", lambda e: self.queue.put_nowait("die")
         )
@@ -204,7 +206,7 @@ class CECPEngine(ProtocolEngine):
             # we will do it after feature accept/reject is completed.
 
     def start(self, event, is_dead):
-        asyncio.create_task(self.__startBlocking(event, is_dead))
+        asyncio.get_event_loop().create_task(self.__startBlocking(event, is_dead))
 
     async def __startBlocking(self, event, is_dead):
         if self.protover == 1:

--- a/lib/pychess/Utils/SetupModel.py
+++ b/lib/pychess/Utils/SetupModel.py
@@ -108,4 +108,4 @@ class SetupModel(GObject.GObject):
                     # print("CLOSE")
                     break
 
-        asyncio.create_task(coro())
+        asyncio.get_event_loop().create_task(coro())

--- a/lib/pychess/ic/ICGameModel.py
+++ b/lib/pychess/ic/ICGameModel.py
@@ -360,7 +360,7 @@ class ICGameModel(GameModel):
                 return
             self.emit("message_received", name, text)
 
-        self.kibitz_task = asyncio.create_task(coro())
+        self.kibitz_task = asyncio.get_event_loop().create_task(coro())
 
     def onWhisperMessage(self, cm, name, gameno, text):
         if gameno != self.ficsgame.gameno:

--- a/lib/pychess/perspectives/learn/EndgamesPanel.py
+++ b/lib/pychess/perspectives/learn/EndgamesPanel.py
@@ -161,7 +161,7 @@ def start_endgame_from(pieces):
     gamemodel.connect("game_started", on_game_started)
 
     perspective = perspective_manager.get_perspective("games")
-    asyncio.create_task(
+    asyncio.get_event_loop().create_task(
         perspective.generalStart(
             gamemodel, p0, p1, loaddata=(StringIO(fen), fen_loader, 0, -1)
         )

--- a/lib/pychess/perspectives/learn/LecturesPanel.py
+++ b/lib/pychess/perspectives/learn/LecturesPanel.py
@@ -129,7 +129,7 @@ def start_lecture_from(filename, index=None):
     gamemodel.connect("game_started", on_game_started)
 
     perspective = perspective_manager.get_perspective("games")
-    asyncio.create_task(perspective.generalStart(gamemodel, p0, p1))
+    asyncio.get_event_loop().create_task(perspective.generalStart(gamemodel, p0, p1))
 
     def lecture_steps(lecture_file):
         with open(lecture_file) as f:
@@ -308,4 +308,4 @@ def start_lecture_from(filename, index=None):
                 # connection.client.run_command("kibitz That concludes this lecture.")
                 break
 
-    asyncio.create_task(coro(gamemodel, steps))
+    asyncio.get_event_loop().create_task(coro(gamemodel, steps))

--- a/lib/pychess/perspectives/learn/LessonsPanel.py
+++ b/lib/pychess/perspectives/learn/LessonsPanel.py
@@ -104,7 +104,7 @@ def start_lesson_game(gamemodel, filename, chessfile, records, index, rec):
 
     gamemodel.status = WAITING_TO_START
     perspective = perspective_manager.get_perspective("games")
-    asyncio.create_task(perspective.generalStart(gamemodel, p0, p1))
+    asyncio.get_event_loop().create_task(perspective.generalStart(gamemodel, p0, p1))
 
 
 # Sidepanel is a class

--- a/lib/pychess/perspectives/learn/PuzzlesPanel.py
+++ b/lib/pychess/perspectives/learn/PuzzlesPanel.py
@@ -181,7 +181,7 @@ def start_puzzle_game(gamemodel, filename, records, index, rec, from_lesson=Fals
     gamemodel.status = WAITING_TO_START
 
     perspective = perspective_manager.get_perspective("games")
-    asyncio.create_task(perspective.generalStart(gamemodel, p0, p1))
+    asyncio.get_event_loop().create_task(perspective.generalStart(gamemodel, p0, p1))
 
 
 # Sidepanel is a class

--- a/lib/pychess/perspectives/learn/generateLessonsSidepanel.py
+++ b/lib/pychess/perspectives/learn/generateLessonsSidepanel.py
@@ -80,7 +80,7 @@ def generateLessonsSidepanel(solving_progress, learn_category_id, entries, start
                     )
                     await asyncio.sleep(0)
 
-            asyncio.create_task(coro())
+            asyncio.get_event_loop().create_task(coro())
 
             self.tv.set_model(self.store)
             self.tv.get_selection().set_mode(Gtk.SelectionMode.BROWSE)

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,8 @@ CLASSIFIERS = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Games/Entertainment :: Board Games",
 ]
 

--- a/testing/analysis.py
+++ b/testing/analysis.py
@@ -78,11 +78,7 @@ class CECPTests(EmittingTestCase):
         self.assertEqual(results, ([(ply, moves, score, depth, nps)],))
 
     def setUp(self):
-        try:
-            self.loop = asyncio.get_event_loop()
-        except RuntimeError:
-            self.loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self.loop)
+        self.loop = asyncio.get_event_loop()
 
         self.engineA, self.analyzerA = self._setupengine(ANALYZING)
         self.engineI, self.analyzerI = self._setupengine(INVERSE_ANALYZING)

--- a/testing/dialogs.py
+++ b/testing/dialogs.py
@@ -27,12 +27,11 @@ class DialogTests(unittest.TestCase):
             from asyncio.windows_events import ProactorEventLoop
 
             loop = ProactorEventLoop()
-            asyncio.set_event_loop(loop)
         else:
             loop = asyncio.SelectorEventLoop()
-            asyncio.set_event_loop(loop)
 
-        self.loop = asyncio.get_event_loop()
+        asyncio.set_event_loop(loop)
+        self.loop = loop
         self.loop.set_debug(enabled=True)
 
         widgets = uistuff.GladeWidgets("PyChess.glade")

--- a/testing/ficsmanagers.py
+++ b/testing/ficsmanagers.py
@@ -139,11 +139,7 @@ class EmittingTestCase(unittest.TestCase):
     Warning: Strong connection to fics managers"""
 
     def setUp(self):
-        try:
-            self.loop = asyncio.get_event_loop()
-        except RuntimeError:
-            self.loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self.loop)
+        self.loop = asyncio.get_event_loop()
 
         self.connection = DummyConnection()
         self.connection.players = FICSPlayers(self.connection)

--- a/testing/learn.py
+++ b/testing/learn.py
@@ -23,12 +23,6 @@ discoverer.pre_discover()
 
 class LearnTests(unittest.TestCase):
     def setUp(self):
-        try:
-            self.loop = asyncio.get_event_loop()
-        except RuntimeError:
-            self.loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self.loop)
-
         widgets = uistuff.GladeWidgets("PyChess.glade")
         gamewidget.setWidgets(widgets)
         perspective_manager.set_widgets(widgets)

--- a/testing/learn.py
+++ b/testing/learn.py
@@ -43,7 +43,7 @@ class LearnTests(unittest.TestCase):
         perspective_manager.current_perspective = self.learn_persp
 
         dd = DiscovererDialog(discoverer)
-        self.dd_task = asyncio.create_task(dd.start())
+        self.dd_task = asyncio.get_event_loop().create_task(dd.start())
 
     def test0(self):
         """Init layout"""

--- a/testing/polyglot.py
+++ b/testing/polyglot.py
@@ -157,11 +157,7 @@ class PolyglotTestCase(unittest.TestCase):
 
             await event.wait()
 
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+        loop = asyncio.get_event_loop()
         loop.set_debug(enabled=True)
 
         loop.run_until_complete(coro())

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -1,3 +1,4 @@
+import asyncio
 import sys
 import unittest
 
@@ -46,6 +47,12 @@ def suite():
 
 
 if __name__ == "__main__":
+    # Python >=3.14 does not auto-create an asyncio event loop for us
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
     ret = unittest.TextTestRunner(verbosity=2).run(suite())
     if ret.wasSuccessful():
         sys.exit(0)

--- a/testing/savegame.py
+++ b/testing/savegame.py
@@ -54,11 +54,7 @@ class DatabaseTests(unittest.TestCase):
     def test1(self):
         """Play and save Human-Human 1 min game"""
 
-        try:
-            loop = asyncio.get_event_loop()
-        except RuntimeError:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
+        loop = asyncio.get_event_loop()
         loop.set_debug(enabled=True)
 
         async def coro():

--- a/testing/selfplay.py
+++ b/testing/selfplay.py
@@ -78,12 +78,10 @@ class CECPTests(unittest.TestCase):
             from asyncio.windows_events import ProactorEventLoop
 
             loop = ProactorEventLoop()
-            asyncio.set_event_loop(loop)
         else:
             loop = asyncio.SelectorEventLoop()
-            asyncio.set_event_loop(loop)
 
-        loop = asyncio.get_event_loop()
+        asyncio.set_event_loop(loop)
         loop.set_debug(enabled=True)
 
         for vari in PYCHESS_VARIANTS:


### PR DESCRIPTION
Fixes #2360

The issue seems to have been that `asyncio.create_task` is **meant to be called from async code** (where a running event loop is guaranteed to be present) while the current code makes calls to that function from non-async (i.e. synchronous) code. For example:

```console
# python3 -c $'import asyncio\nasync def dummy():\n\tpass\nasyncio.create_task(dummy())'
Traceback (most recent call last):
  File "<string>", line 4, in <module>
  File "/usr/lib/python3.11/asyncio/tasks.py", line 381, in create_task
    loop = events.get_running_loop()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: no running event loop
sys:1: RuntimeWarning: coroutine 'dummy' was never awaited

# python3 -c $'import asyncio\nasync def dummy():\n\tpass\nasyncio.get_event_loop().create_task(dummy()); print("created.")'
created.
```

Follow-up to…
- #2359
- #2361


CC @gbtami @AdamWill 