### PR TITLE
Make GitHub Actions keep pre-commit hooks up to date

### DIFF
--- a/.github/workflows/pre-commit-detect-outdated.yml
+++ b/.github/workflows/pre-commit-detect-outdated.yml
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 Sebastian Pipping <sebastian@pipping.org>
+# Licensed under GPL v3 or later
+
+name: Detect outdated pre-commit hooks
+
+on:
+  schedule:
+    - cron: '0 16 * * 5'  # Every Friday 4pm
+
+# NOTE: This will drop all permissions from GITHUB_TOKEN except metadata read,
+#       and then (re)add the ones listed below:
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  pre_commit_detect_outdated:
+    name: Detect outdated pre-commit hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: 3.13
+
+      - name: Install pre-commit
+        run: |-
+          pip install \
+            --disable-pip-version-check \
+            --no-warn-script-location \
+            --user \
+            pre-commit
+          echo "PATH=${HOME}/.local/bin:${PATH}" >> "${GITHUB_ENV}"
+
+      - name: Check for outdated hooks
+        run: |-
+          pre-commit autoupdate
+          git diff -- .pre-commit-config.yaml
+
+      - name: Create pull request from changes (if any)
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e  # v7.0.8
+        with:
+          author: 'pre-commit <pre-commit@tools.invalid>'
+          base: master
+          body: |-
+            For your consideration.
+
+            :warning: Please **CLOSE AND RE-OPEN** this pull request so that [further workflow runs get triggered](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) for this pull request.
+          branch: precommit-autoupdate
+          commit-message: "pre-commit: Autoupdate"
+          delete-branch: true
+          draft: true
+          labels: enhancement
+          title: "pre-commit: Autoupdate"
+
+      - name: Log pull request URL
+        if: "${{ steps.create-pull-request.outputs.pull-request-url }}"
+        run: |
+          echo "Pull request URL is: ${{ steps.create-pull-request.outputs.pull-request-url }}"


### PR DESCRIPTION
In reaction to https://github.com/pychess/pychess/pull/2366#issuecomment-3114503176

Will need this change in settings for a chance to create pull requests:

<img width="824" height="875" alt="pull_requests" src="https://github.com/user-attachments/assets/339be95e-f1e1-4891-8e44-1cc66df99784" />

@gbtami what do you think?