### PR TITLE
Drop support for near-end-of-life Python <=3.9

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.14"]  # no particular need for in-between versions
+        python-version: ["3.10", "3.14"]  # no particular need for in-between versions
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,13 +3,13 @@ repos:
     rev: v3.21.0
     hooks:
     -  id: pyupgrade
-       args: ['--py39-plus']
+       args: ['--py310-plus']
 
   - repo: https://github.com/psf/black
     rev: 25.9.0
     hooks:
       - id: black
-        args: ['--target-version', 'py39']
+        args: ['--target-version', 'py310']
         exclude: 'doc/createDoc'
 
   - repo: https://github.com/pycqa/flake8

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ PyChess is an open-source project, and contributions are welcome! Whether you wa
      ```
 
 2. **Set Up Your Development Environment**
-   - Ensure you have Python 3.9 or newer installed.
+   - Ensure you have Python 3.10 or newer installed.
    - Install the required dependencies:
      ```bash
      pip install -r requirements.txt

--- a/lib/pychess/Utils/__init__.py
+++ b/lib/pychess/Utils/__init__.py
@@ -89,8 +89,6 @@ class wait_signal(asyncio.Future):
             return False
         try:
             super().cancel(msg=msg)
-        except TypeError:  # It has msg parameter only form Python 3.9
-            super().cancel()
         except AttributeError:
             pass
         try:

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,6 @@ CLASSIFIERS = [
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: POSIX",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
 Package: pychess
-X-Python3-Version: >= 3.9
+X-Python3-Version: >= 3.10
 Depends3: gnome-icon-theme, python3-gi, python3-gi-cairo, gobject-introspection,
  gir1.2-glib-2.0, gir1.2-gtk-3.0, gir1.2-pango-1.0, gir1.2-rsvg-2.0,
  gir1.2-gdkpixbuf-2.0, gir1.2-gtksource-4, python3-cairo, python3-sqlalchemy,


### PR DESCRIPTION
https://endoflife.date/python