### PR TITLE
Fix CI / Workaround issues with pip >=25.3

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -66,6 +66,8 @@ jobs:
         time PYTHONPATH=lib python3 pgn2ecodb.py
         time PYTHONPATH=lib python3 create_theme_preview.py
 
+        python3 setup.py --version  # workaround for pip >=25.3, creates file "learn/puzzles/mate_in_4.sqlite"
+
         pip3 install -e .
 
         pychess --help  # smoke test

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -107,6 +107,8 @@ jobs:
         time PYTHONPATH=lib python3 pgn2ecodb.py
         time PYTHONPATH=lib python3 create_theme_preview.py
 
+        python3 setup.py --version  # workaround for pip >=25.3, creates file "learn/puzzles/mate_in_4.sqlite"
+
         pip3 install -e .
 
         pychess --help  # smoke test

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -64,6 +64,8 @@ jobs:
         time PYTHONPATH=lib python3 pgn2ecodb.py
         time PYTHONPATH=lib python3 create_theme_preview.py
 
+        python3 setup.py --version  # workaround for pip >=25.3, creates file "learn/puzzles/mate_in_4.sqlite"
+
         pip3 install -e .
 
         pychess --help  # smoke test


### PR DESCRIPTION
The import `from pychess.Savers.pgn import PGNFile` in file `setup.py` internally does an `import pexpect` which started failing with error `ModuleNotFoundError: No module named 'pexpect'` because pip >=25.3 no longer respects the outer virtualenv during `pip3 install .`. This is a workaround only. Likely a migration to `pyproject.toml` is needed for a proper fix.