### PR TITLE
`setup.py`: Fix call to `cx_Freeze.Executable` for cx_Freeze >=8.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -288,7 +288,7 @@ if msi:
     base = None
     # Lets not open the console while running the app
     if sys.platform == "win32":
-        base = "Win32GUI"
+        base = "gui"
 
     executables = [
         Executable(


### PR DESCRIPTION
The symptom was:
```
distutils.errors.DistutilsOptionError: no base named 'legacy/win32gui' ('legacy/win32gui-cpython-313-mingw_x86_64_msvcrt_gnu.exe') - Did you mean 'gui'?
```

Related:
- https://cx-freeze.readthedocs.io/en/stable/setup_script.html#cmdoption-arg-base
- https://github.com/marcelotduarte/cx_Freeze/issues/3184#issuecomment-3572244587
- https://github.com/marcelotduarte/cx_Freeze/commit/d1d28555dd578a7cdb76f18f8f02912c0b2a0c19