### PR TITLE
`requirements-dev.txt`: Bump Black to 26.3.1

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==25.12.0
+black==26.3.1
 flake8==7.3.0
 pyupgrade==3.21.2
 pre-commit


### PR DESCRIPTION
.. to match pre-commit (commit ec1363faaf0cc44e51a2b88d4fe052cdb0f9abda) and to address [the Dependabot Security alert](https://github.com/pychess/pychess/security/dependabot/5)