### PR TITLE
`remotegame.py`: Drop broken support for chess-samara.ru

### DIFF
--- a/lib/pychess/Savers/remotegame.py
+++ b/lib/pychess/Savers/remotegame.py
@@ -1731,36 +1731,6 @@ class InternetGameRedhotpawn(InternetGameInterface):
         return None
 
 
-# Chess-Samara.ru
-class InternetGameChesssamara(InternetGameInterface):
-    def get_identity(self):
-        return "Chess-Samara.ru", CAT_DL
-
-    def assign_game(self, url):
-        rxp = re.compile(
-            r"^https?:\/\/(\S+\.)?chess-samara\.ru\/(\d+)\-", re.IGNORECASE
-        )
-        m = rxp.match(url)
-        if m is not None:
-            gid = str(m.group(2))
-            if gid.isdigit() and gid != "0":
-                self.id = gid
-                return True
-        return False
-
-    def download_game(self):
-        # Check
-        if self.id is None:
-            return None
-
-        # Download
-        pgn = self.download("https://chess-samara.ru/view/pgn.html?gameid=%s" % self.id)
-        if pgn is None or len(pgn) == 0:
-            return None
-        else:
-            return pgn
-
-
 # 2700chess.com
 class InternetGame2700chess(InternetGameInterface):
     def get_identity(self):
@@ -2391,7 +2361,6 @@ chess_providers = [
     InternetGameChessCom(),
     InternetGameSchachspielen(),
     InternetGameRedhotpawn(),
-    InternetGameChesssamara(),
     InternetGame2700chess(),
     InternetGameSchacharena(),
     InternetGameChesspuzzle(),

--- a/testing/remotegame.py
+++ b/testing/remotegame.py
@@ -17,7 +17,6 @@ from pychess.Savers.remotegame import (
     InternetGameChessCom,
     InternetGameSchachspielen,
     InternetGameRedhotpawn,
-    InternetGameChesssamara,
     InternetGame2700chess,
     InternetGameSchacharena,
     InternetGameChesspuzzle,
@@ -415,24 +414,6 @@ class RemoteGameTestCase(unittest.TestCase):
             ),
         ]  # Not a puzzle (wrong ID)
         self.executeTest(InternetGameRedhotpawn(), links)
-
-    def testChesssamara(self):
-        links = [
-            (
-                "https://chess-SAMARA.ru/68373335-igra-Firudin1888-vs-Pizyk",
-                True,
-            ),  # Game
-            (
-                "https://chess-samara.ru/view/pgn.html?gameid=68373335",
-                False,
-            ),  # Game in direct link but handled by the generic extractor
-            (
-                "https://chess-samara.ru/1234567890123-pychess-vs-pychess",
-                False,
-            ),  # Not a game (wrong ID)
-            ("https://chess-samara.ru", False),
-        ]  # Not a game (homepage)
-        self.executeTest(InternetGameChesssamara(), links)
 
     @unittest.skip("You need to be a Premium Member to have access to this feature.")
     def test2700chess(self):


### PR DESCRIPTION
CI started failing at https://github.com/pychess/pychess/actions/runs/24031433576/job/70095343776?pr=2466#step:6:5736 due to new anti-bot captures on the target site:

<img width="553" height="325" alt="samara" src="https://github.com/user-attachments/assets/eb243d97-ce44-4eb1-a00e-7d9623511f5e" />

CC @gbtami 