### PR TITLE
Resume stopped engine process before terminate

### DIFF
--- a/lib/pychess/System/SubProcess.py
+++ b/lib/pychess/System/SubProcess.py
@@ -155,6 +155,7 @@ class SubProcess(GObject.GObject):
         if self.write_task is not None:
             self.write_task.cancel()
         self.read_stdout_task.cancel()
+        self.resume()
         try:
             self.proc.terminate()
             log.debug("SubProcess.terminate()", extra={"task": self.defname})


### PR DESCRIPTION
Engines wouldn't terminate correctly after closing a game and stay until the application is closed. If the process was stopped with SIGSTOP, SIGTERM is not handled until a SIGCONT is received. Adding a `self.resume()` call seams to fix it on my archlinux with stockfish and PyChess.py.

This should fix the following issues: #2242 #2210

Just to let you know, I'm not 100% sure it is enough since I'm not very good at Python subprocesses and async io. I was initially testing with my custom engine that creates some processes of its own. The fix works When removing the subprocesses creation, but with them on it still hangs half the time and SIGTERM is only received when the app is closed. Adding `self.proc.stdin.close()` along with the `self.resume()` fixes it. I didn't included it in the commit since it may be some bad signal handling on my part.
