### PR TITLE
`setup.py`: Drop a Python 3.9 leftover (follow-up to #2406)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -375,7 +375,7 @@ setup(
     license="GPL3",
     url="https://pychess.github.io/",
     download_url="https://github.com/pychess/pychess/releases",
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         "pexpect",
         "psutil",


### PR DESCRIPTION
Follow-up to commit 3a4bfbaf4250b4470ded727813d9f17c9b1f5422 from pull request #2406