### PR TITLE
Fix Chess960 castling logic in Setup Position dialog

### DIFF
--- a/lib/pychess/Utils/lutils/LBoard.py
+++ b/lib/pychess/Utils/lutils/LBoard.py
@@ -439,6 +439,27 @@ class LBoard:
                 elif char == "q":
                     castling |= B_OOO
                     self.ini_rooks[1][0] = rank8.find("r") + 56
+            elif self.variant == SETUPCHESS:
+                if char == "K":
+                    castling |= W_OO
+                elif char == "Q":
+                    castling |= W_OOO
+                elif char == "k":
+                    castling |= B_OO
+                elif char == "q":
+                    castling |= B_OOO
+                elif char in reprFile and self.kings[BLACK] >= 0:
+                    # X-FEN file letter (a-h) for a black castling right
+                    if char > reprCord[self.kings[BLACK]][0]:
+                        castling |= B_OO
+                    else:
+                        castling |= B_OOO
+                elif char.lower() in reprFile and self.kings[WHITE] >= 0:
+                    # X-FEN file letter (A-H) for a white castling right
+                    if char.lower() > reprCord[self.kings[WHITE]][0]:
+                        castling |= W_OO
+                    else:
+                        castling |= W_OOO
             else:
                 if char == "K":
                     castling |= W_OO

--- a/lib/pychess/widgets/newGameDialog.py
+++ b/lib/pychess/widgets/newGameDialog.py
@@ -44,8 +44,8 @@ from pychess.Utils.const import (
     UNSUPPORTED,
     ARTIFICIAL,
     LOCAL,
-    reprCord,
     reprFile,
+    ROOK,
     W_OO,
     W_OOO,
     B_OO,
@@ -1093,32 +1093,54 @@ class SetupPositionExtension(_GameInitializationMode):
 
     @classmethod
     def castl_toggled(cls, button, castl):
-        lboard = cls.setupmodel.boards[-1].board
-        # TODO: this doesn't work at all
-        if lboard.variant == FISCHERRANDOMCHESS:
-            if castl == W_OO:
-                cast_letter = reprCord[lboard.ini_rooks[0][1]][0].upper()
-            elif castl == W_OOO:
-                cast_letter = reprCord[lboard.ini_rooks[0][0]][0].upper()
-            elif castl == B_OO:
-                cast_letter = reprCord[lboard.ini_rooks[1][1]][0]
-            elif castl == B_OOO:
-                cast_letter = reprCord[lboard.ini_rooks[1][0]][0]
-        else:
-            if castl == W_OO:
-                cast_letter = "K"
-            elif castl == W_OOO:
-                cast_letter = "Q"
-            elif castl == B_OO:
-                cast_letter = "k"
-            elif castl == B_OOO:
-                cast_letter = "q"
-
         if button.get_active():
-            cls.castl.add(cast_letter)
+            cls.castl.add(castl)
         else:
-            cls.castl.discard(cast_letter)
+            cls.castl.discard(castl)
         cls.fen_changed()
+
+    @classmethod
+    def _castling_field(cls, variant, pieces):
+        if not cls.castl:
+            return "-"
+
+        if variant == FISCHERRANDOMCHESS:
+            lboard = LBoard(FISCHERRANDOMCHESS)
+            lboard.applyFen("%s w - - 0 1" % pieces)
+
+            castling = 0
+            for flag in cls.castl:
+                castling |= flag
+            lboard.castling = castling
+
+            for color, rank_start in ((WHITE, 0), (BLACK, 56)):
+                king = lboard.kings[color]
+                if king < 0:
+                    continue
+                rooks = [
+                    cord
+                    for cord in range(rank_start, rank_start + 8)
+                    if lboard.arBoard[cord] == ROOK
+                ]
+                left = [cord for cord in rooks if cord < king]
+                right = [cord for cord in rooks if cord > king]
+                if left:
+                    lboard.ini_rooks[color][0] = min(left)
+                if right:
+                    lboard.ini_rooks[color][1] = max(right)
+
+            return lboard.reprCastling()
+
+        strs = []
+        if W_OO in cls.castl:
+            strs.append("K")
+        if W_OOO in cls.castl:
+            strs.append("Q")
+        if B_OO in cls.castl:
+            strs.append("k")
+        if B_OOO in cls.castl:
+            strs.append("q")
+        return "".join(strs)
 
     @classmethod
     def get_fen(cls):
@@ -1134,7 +1156,7 @@ class SetupPositionExtension(_GameInitializationMode):
         pieces = cls.setupmodel.boards[-1].as_fen(variant.variant)
 
         side = "b" if cls.widgets["side_button"].get_active() else "w"
-        castl = "".join(sorted(cls.castl)) if cls.castl else "-"
+        castl = cls._castling_field(variant.variant, pieces)
 
         ep = "-"
         rank = "3" if side == "b" else "6"

--- a/lib/pychess/widgets/newGameDialog.py
+++ b/lib/pychess/widgets/newGameDialog.py
@@ -1108,15 +1108,16 @@ class SetupPositionExtension(_GameInitializationMode):
             lboard = LBoard(FISCHERRANDOMCHESS)
             lboard.applyFen("%s w - - 0 1" % pieces)
 
-            castling = 0
+            requested = 0
             for flag in cls.castl:
-                castling |= flag
-            lboard.castling = castling
+                requested |= flag
 
+            effective = 0
             for color, rank_start in ((WHITE, 0), (BLACK, 56)):
                 king = lboard.kings[color]
                 if king < 0:
                     continue
+                oo, ooo = (W_OO, W_OOO) if color == WHITE else (B_OO, B_OOO)
                 rooks = [
                     cord
                     for cord in range(rank_start, rank_start + 8)
@@ -1124,11 +1125,14 @@ class SetupPositionExtension(_GameInitializationMode):
                 ]
                 left = [cord for cord in rooks if cord < king]
                 right = [cord for cord in rooks if cord > king]
-                if left:
+                if (requested & ooo) and left:
                     lboard.ini_rooks[color][0] = min(left)
-                if right:
+                    effective |= ooo
+                if (requested & oo) and right:
                     lboard.ini_rooks[color][1] = max(right)
+                    effective |= oo
 
+            lboard.castling = effective
             return lboard.reprCastling()
 
         strs = []

--- a/lib/pychess/widgets/newGameDialog.py
+++ b/lib/pychess/widgets/newGameDialog.py
@@ -57,6 +57,7 @@ from pychess.Utils.const import (
 )
 
 from pychess.Utils.repr import localReprSign
+from pychess.Utils.lutils.bitboard import bitPosArray
 from pychess.Utils.lutils.ldata import FILE
 from pychess.Utils.lutils.LBoard import LBoard
 from pychess.System import uistuff
@@ -1115,13 +1116,14 @@ class SetupPositionExtension(_GameInitializationMode):
             effective = 0
             for color, rank_start in ((WHITE, 0), (BLACK, 56)):
                 king = lboard.kings[color]
-                if king < 0:
+                if not (rank_start <= king < rank_start + 8):
                     continue
                 oo, ooo = (W_OO, W_OOO) if color == WHITE else (B_OO, B_OOO)
                 rooks = [
                     cord
                     for cord in range(rank_start, rank_start + 8)
                     if lboard.arBoard[cord] == ROOK
+                    and (bitPosArray[cord] & lboard.friends[color])
                 ]
                 left = [cord for cord in rooks if cord < king]
                 right = [cord for cord in rooks if cord > king]

--- a/testing/dialogs.py
+++ b/testing/dialogs.py
@@ -7,7 +7,7 @@ import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-from pychess.Utils.const import FEN_START, NORMALCHESS
+from pychess.Utils.const import FEN_START, NORMALCHESS, FISCHERRANDOMCHESS
 from pychess.Players.engineNest import discoverer
 from pychess.System import uistuff, cancel_all_tasks
 from pychess.widgets import gamewidget
@@ -89,6 +89,34 @@ class DialogTests(unittest.IsolatedAsyncioTestCase):
         dialog.widgets["newgamedialog"].response(Gtk.ResponseType.OK)
 
         await asyncio.wait_for(event.wait(), timeout=5)
+
+        newGameDialog.NewGameMode.widgets["newgamedialog"].hide()
+
+    async def test2_frc_castling(self):
+        """Setup Position dialog round-trips Chess960 file-letter castling"""
+
+        dialog = newGameDialog.SetupPositionExtension()
+
+        # A Chess960 start position with non-standard king/rook files.
+        frc_fen = "nrbbqknr/pppppppp/8/8/8/8/PPPPPPPP/NRBBQKNR w KQkq - 0 1"
+        dialog.run(frc_fen, FISCHERRANDOMCHESS)
+
+        # Loading the position should tick all four castling checkboxes.
+        self.assertTrue(dialog.widgets["woo"].get_active())
+        self.assertTrue(dialog.widgets["wooo"].get_active())
+        self.assertTrue(dialog.widgets["boo"].get_active())
+        self.assertTrue(dialog.widgets["booo"].get_active())
+
+        # ngvariant1 defaults to FISCHERRANDOMCHESS, so get_fen must emit
+        # X-FEN file letters rather than classical KQkq or "-".
+        dialog.widgets["playVariant1Radio"].set_active(True)
+        castl = dialog.get_fen().split()[2]
+        self.assertEqual(castl, "HBhb")
+
+        # Classical chess still produces canonical KQkq from the same flags.
+        dialog.widgets["playNormalRadio"].set_active(True)
+        castl = dialog.get_fen().split()[2]
+        self.assertEqual(castl, "KQkq")
 
         newGameDialog.NewGameMode.widgets["newgamedialog"].hide()
 

--- a/testing/dialogs.py
+++ b/testing/dialogs.py
@@ -118,7 +118,11 @@ class DialogTests(unittest.IsolatedAsyncioTestCase):
         castl = dialog.get_fen().split()[2]
         self.assertEqual(castl, "KQkq")
 
-        newGameDialog.NewGameMode.widgets["newgamedialog"].hide()
+        # Send a response so the dialog hides *and* disconnects its response
+        # handler. A bare hide() would leave the SetupPosition handler attached
+        # to the shared newgamedialog, causing it to also fire (and spawn a
+        # stray game) on the next test's OK response.
+        dialog.widgets["newgamedialog"].response(Gtk.ResponseType.CANCEL)
 
     @unittest.skipIf(
         sys.platform == "win32",

--- a/testing/frc_castling.py
+++ b/testing/frc_castling.py
@@ -106,5 +106,34 @@ class SetupCastlingTestCase(unittest.TestCase):
             self.assertEqual(board.castling, expected, fen)
 
 
+# (piece placement, ticked castling flags, expected castling field) for the
+# Setup Position dialog's FRC castling helper. The adversarial cases ensure a
+# right ticked without a matching rook (or king) is dropped instead of crashing
+# with reprCord[None] in reprCastling().
+dialog_data = (
+    # Happy path: standard back rank, all four rights ticked.
+    (
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR",
+        (W_OO, W_OOO, B_OO, B_OOO),
+        "HAha",
+    ),
+    # Kingside ticked but no rook to the right of the king -> dropped.
+    ("4k3/8/8/8/8/8/8/R3K3", (W_OO,), "-"),
+    # Both white rights ticked but the white king is missing -> dropped.
+    ("4k3/8/8/8/8/8/8/R6R", (W_OO, W_OOO), "-"),
+)
+
+
+class DialogFRCCastlingFieldTestCase(unittest.TestCase):
+    def testCastlingFieldGuards(self):
+        """Testing Setup dialog _castling_field FRC guards against missing rook/king"""
+        from pychess.widgets.newGameDialog import SetupPositionExtension
+
+        for pieces, flags, expected in dialog_data:
+            SetupPositionExtension.castl = set(flags)
+            result = SetupPositionExtension._castling_field(FISCHERRANDOMCHESS, pieces)
+            self.assertEqual(result, expected, pieces)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/testing/frc_castling.py
+++ b/testing/frc_castling.py
@@ -14,6 +14,11 @@ from pychess.Utils.const import (
     FISCHERRANDOMCHESS,
     KING_CASTLE,
     QUEEN_CASTLE,
+    SETUPCHESS,
+    W_OO,
+    W_OOO,
+    B_OO,
+    B_OOO,
 )
 from pychess.Utils.lutils.LBoard import LBoard
 from pychess.Utils.lutils.lmove import parseAN
@@ -71,6 +76,34 @@ class FRCCastlingTestCase(unittest.TestCase):
         # print board
         moves = [move for move in genCastles(board)]
         self.assertTrue(parseAN(board, "e1g1") in moves)
+
+
+# (FEN, expected castling flags) for X-FEN file-letter rights parsed as SETUPCHESS.
+# This mirrors how the Setup Position dialog re-parses a loaded Chess960 position.
+setup_data = (
+    (
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w AHah - 0 1",
+        W_OO | W_OOO | B_OO | B_OOO,
+    ),
+    ("1br3kr/2p5/8/8/8/8/8/1BR3KR w CH - 0 2", W_OO | W_OOO),
+    ("1br3kr/2p5/8/8/8/8/8/1BR3KR b ch - 0 2", B_OO | B_OOO),
+    ("2r1k2r/8/8/8/8/8/8/2R1K2R w H - 0 1", W_OO),
+    ("2r1k2r/8/8/8/8/8/8/2R1K2R b h - 0 1", B_OO),
+    (
+        "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        W_OO | W_OOO | B_OO | B_OOO,
+    ),
+    ("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1", 0),
+)
+
+
+class SetupCastlingTestCase(unittest.TestCase):
+    def testSetupFileLetterCastling(self):
+        """Testing SETUPCHESS X-FEN file-letter castling parsing"""
+        for fen, expected in setup_data:
+            board = LBoard(SETUPCHESS)
+            board.applyFen(fen)
+            self.assertEqual(board.castling, expected, fen)
 
 
 if __name__ == "__main__":

--- a/testing/frc_castling.py
+++ b/testing/frc_castling.py
@@ -121,6 +121,12 @@ dialog_data = (
     ("4k3/8/8/8/8/8/8/R3K3", (W_OO,), "-"),
     # Both white rights ticked but the white king is missing -> dropped.
     ("4k3/8/8/8/8/8/8/R6R", (W_OO, W_OOO), "-"),
+    # White king off the back rank (on e2) -> back-rank rooks ignored, dropped.
+    ("4k3/8/8/8/8/8/4K3/R6R", (W_OO, W_OOO), "-"),
+    # Queenside ticked but the only left-of-king rook is the opponent's -> dropped.
+    ("4k3/8/8/8/8/8/8/r3K2R", (W_OOO,), "-"),
+    # Same position: kingside white rook (h1) is valid and emitted.
+    ("4k3/8/8/8/8/8/8/r3K2R", (W_OO,), "H"),
 )
 
 


### PR DESCRIPTION
This pull request improves the handling and testing of castling rights, especially for Chess960 (Fischer Random Chess) and custom setup positions, across the PyChess codebase. The main changes ensure that castling rights are correctly parsed, displayed, and round-tripped in both the UI and backend logic, with robust handling of edge cases such as missing kings or rooks. Additionally, comprehensive tests have been added to verify these behaviors. Fixes #1869 

**Castling rights parsing and display improvements:**

* Enhanced `LBoard.applyFen` to correctly parse X-FEN file-letter castling rights for the `SETUPCHESS` variant, supporting both classical and Chess960 notations and handling custom king/rook positions.
* Reworked the Setup Position dialog (`newGameDialog.py`) to use internal castling flags instead of castling letters, and added a `_castling_field` helper to generate the correct castling field in FEN for both standard and Chess960 variants, including robust guards against missing kings or rooks. [[1]](diffhunk://#diff-52c996d58fe1f88e65f8cbde8609acee92d6d0f566fef2e475398e1949a64451L1096-R1150) [[2]](diffhunk://#diff-52c996d58fe1f88e65f8cbde8609acee92d6d0f566fef2e475398e1949a64451L1137-R1165)

**Test coverage enhancements:**

* Added new unit tests in `frc_castling.py` to verify correct parsing of X-FEN castling rights for `SETUPCHESS` and to ensure the dialog's castling field generation handles adversarial cases (e.g., missing pieces) gracefully.
* Introduced a dialog round-trip test in `dialogs.py` to confirm that castling rights are preserved and correctly displayed when loading and saving Chess960 positions via the Setup Position dialog.

**Codebase maintenance and imports:**

* Updated imports in various files to support the new logic and tests, ensuring all necessary constants and helpers are available. [[1]](diffhunk://#diff-52c996d58fe1f88e65f8cbde8609acee92d6d0f566fef2e475398e1949a64451L47-R48) [[2]](diffhunk://#diff-52c996d58fe1f88e65f8cbde8609acee92d6d0f566fef2e475398e1949a64451R60) [[3]](diffhunk://#diff-038c972976a376649969c88ca84b3f1b54d0602c5df858d540a94f31d99334caL10-R10) [[4]](diffhunk://#diff-ebbdfaa56729bed7f7350f92f2864d8790e6e530a6445ecfa32d89d8349fdeceR17-R21)