### PR TITLE
Add language selection to Preferences (#2500)

### DIFF
--- a/glade/PyChess.glade
+++ b/glade/PyChess.glade
@@ -1420,6 +1420,45 @@ Ticked : the linear scale focuses on a limited range around the null average. It
                                         <property name="position">12</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkHBox" id="langbox">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="spacing">6</property>
+                                        <child>
+                                          <object class="GtkLabel" id="langlabel">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="halign">start</property>
+                                            <property name="label" translatable="yes">_Language:</property>
+                                            <property name="use-underline">True</property>
+                                            <property name="mnemonic-widget">langcombo</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkComboBox" id="langcombo">
+                                            <property name="visible">True</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Choose the display language. Changes take effect after you restart PyChess.</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">13</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/lib/pychess/System/conf.py
+++ b/lib/pychess/System/conf.py
@@ -93,6 +93,9 @@ DEFAULTS = {
     "General": {
         "firstName": username,
         "secondName": _("Guest"),
+        # Preferred UI language as a locale code (e.g. "de", "ml").
+        # An empty string means "follow the system locale".
+        "langcombo": "",
         "showEmt": False,
         "showEval": False,
         "showBlunder": True,

--- a/lib/pychess/widgets/preferencesDialog.py
+++ b/lib/pychess/widgets/preferencesDialog.py
@@ -100,6 +100,101 @@ def initialize(widgets):
 # General initing
 
 
+# Human readable names for the locales PyChess ships translations for.
+# Keys are the locale directory names under lang/. Anything not listed
+# falls back to showing the bare locale code.
+LANGUAGE_NAMES = {
+    "af": "Afrikaans",
+    "ar": "العربية",
+    "az": "Azərbaycanca",
+    "bg": "Български",
+    "bn": "বাংলা",
+    "br": "Brezhoneg",
+    "ca": "Català",
+    "cs": "Čeština",
+    "da": "Dansk",
+    "de": "Deutsch",
+    "el": "Ελληνικά",
+    "en": "English",
+    "en_GB": "English (United Kingdom)",
+    "es": "Español",
+    "et": "Eesti",
+    "eu": "Euskara",
+    "eu_ES": "Euskara (Espainia)",
+    "fa": "فارسی",
+    "fi": "Suomi",
+    "fr": "Français",
+    "ga": "Gaeilge",
+    "gl": "Galego",
+    "he": "עברית",
+    "hi": "हिन्दी",
+    "hr": "Hrvatski",
+    "hu": "Magyar",
+    "id": "Bahasa Indonesia",
+    "is": "Íslenska",
+    "it": "Italiano",
+    "ja": "日本語",
+    "jv": "Basa Jawa",
+    "ka": "ქართული",
+    "kn": "ಕನ್ನಡ",
+    "ko": "한국어",
+    "ku": "Kurdî",
+    "lt": "Lietuvių",
+    "lv": "Latviešu",
+    "ml": "മലയാളം",
+    "mr": "मराठी",
+    "ms_MY": "Bahasa Melayu",
+    "nb": "Norsk bokmål",
+    "nl": "Nederlands",
+    "oc": "Occitan",
+    "pl": "Polski",
+    "pl_PL": "Polski (Polska)",
+    "pt": "Português",
+    "pt_BR": "Português (Brasil)",
+    "ro": "Română",
+    "ru": "Русский",
+    "si": "සිංහල",
+    "sk": "Slovenčina",
+    "sl": "Slovenščina",
+    "sq": "Shqip",
+    "sv": "Svenska",
+    "te": "తెలుగు",
+    "tr": "Türkçe",
+    "uk": "Українська",
+    "vi": "Tiếng Việt",
+    "wa": "Walon",
+    "zh_CN": "中文 (简体)",
+    "zu": "isiZulu",
+}
+
+
+def get_available_languages():
+    """Return a list of (code, display_name) for shipped translations.
+
+    Scans the lang/ directory for locales that provide a message catalog.
+    The list is sorted by display name. The empty-string code used for
+    "follow the system locale" is not included here; callers prepend it.
+    """
+    langs = []
+    lang_dir = addDataPrefix("lang")
+    try:
+        entries = listdir(lang_dir)
+    except OSError:
+        entries = []
+    for code in entries:
+        lc_messages = os.path.join(lang_dir, code, "LC_MESSAGES")
+        if not isdir(lc_messages):
+            continue
+        has_catalog = isfile(os.path.join(lc_messages, "pychess.mo")) or isfile(
+            os.path.join(lc_messages, "pychess.po")
+        )
+        if not has_catalog:
+            continue
+        langs.append((code, LANGUAGE_NAMES.get(code, code)))
+    langs.sort(key=lambda item: item[1].lower())
+    return langs
+
+
 class GeneralTab:
     def __init__(self, widgets):
         # Give to uistuff.keeper
@@ -111,6 +206,7 @@ class GeneralTab:
                 "pieceTheme",
                 "board_style",
                 "board_frame",
+                "langcombo",
             ):
                 continue
 
@@ -121,6 +217,33 @@ class GeneralTab:
                 print("GeneralTab AttributeError", key, conf.DEFAULTS["General"][key])
             except TypeError:
                 print("GeneralTab TypeError", key, conf.DEFAULTS["General"][key])
+
+        # Language selection. The combo stores a locale code in conf
+        # (empty string == follow the system locale). Switching language
+        # only takes effect after a restart, since translations are bound
+        # when widgets are built.
+        lang_combo = widgets["langcombo"]
+        # codes[i] is the locale code matching row i of the combo model.
+        self.lang_codes = [""] + [code for code, _name in get_available_languages()]
+        data = [(None, _("System default"))] + [
+            (None, name) for _code, name in get_available_languages()
+        ]
+        uistuff.createCombo(lang_combo, data, name="langcombo")
+
+        def _get_lang(combobox):
+            active = combobox.get_active()
+            if active < 0 or active >= len(self.lang_codes):
+                return ""
+            return self.lang_codes[active]
+
+        def _set_lang(combobox, value):
+            try:
+                index = self.lang_codes.index(value)
+            except ValueError:
+                index = 0
+            combobox.set_active(index)
+
+        uistuff.keep(lang_combo, "langcombo", _get_lang, _set_lang)
 
 
 # Hint initing

--- a/pychess
+++ b/pychess
@@ -176,6 +176,27 @@ if no_gettext:
     os.environ["LANG"] = "C"
     locale.setlocale(locale.LC_ALL, "C")
 else:
+    # Honor a UI language chosen in Preferences (stored in the config
+    # file as General/langcombo). An empty value means "follow the system
+    # locale". Setting LANGUAGE makes gettext prefer that catalog. This is
+    # read here, before gettext.install(), because translations are bound
+    # when widgets are built, so the choice applies on the next startup.
+    try:
+        import configparser
+
+        from pychess.System import prefix as _prefix
+
+        _cfg = configparser.RawConfigParser()
+        _cfg_path = _prefix.addUserConfigPrefix("config")
+        if os.path.isfile(_cfg_path):
+            _cfg.read(_cfg_path)
+            _ui_lang = _cfg.get("General", "langcombo", fallback="").strip()
+            if _ui_lang:
+                os.environ["LANGUAGE"] = _ui_lang
+    except Exception:
+        # Never let a bad config file prevent PyChess from starting.
+        pass
+
     locale.setlocale(locale.LC_ALL, "")
     # http://stackoverflow.com/questions/3678174/python-gettext-doesnt-load-translations-on-windows
     if sys.platform.startswith("win"):


### PR DESCRIPTION
Closes #2500.

Adds a Language dropdown to the General tab of Preferences so users can choose a UI language without changing their system locale.

Changes:
- glade/PyChess.glade: add a Language label and `langcombo` to the General Options box.
- conf.py: add a `General/langcombo` default, where an empty string means follow the system locale.
- preferencesDialog.py: discover the catalogs already shipped under `lang/`, populate the combo with readable language names, and persist the chosen locale code (not a positional index, so it stays stable if the language list changes).
- pychess launcher: read the setting before `gettext.install()` and set `LANGUAGE` so the chosen catalog loads.

Behavior:
As discussed in the issue, this applies on the next restart rather than switching live, since translations are bound when widgets are built and the windows are cached singletons. The combo tooltip notes the restart requirement. A true live switch would be a larger, separate effort.

Testing:
ruff lint and format pass. Loading the edited glade in a real GTK3 GtkBuilder succeeds, with the language widgets created, correctly typed, and placed in the General Options box. The catalog discovery, combo population, and config persistence (selecting a language writes its locale code, "System default" writes an empty string) were verified against the actual code under Xvfb. I was not able to do a full interactive run with compiled catalogs, so a visual confirmation of the restart switch on Linux would be welcome.