### PR TITLE
Limit CI runtime and package installation runtime

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build-deb:
     name: Build DEB package for Linux
+    timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -24,7 +25,7 @@ jobs:
       run: |
         set -x
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes -V \
+        sudo timeout 10m apt-get install --no-install-recommends --yes -V \
             build-essential \
             debhelper \
             dh-python \

--- a/.github/workflows/build-rpm.yml
+++ b/.github/workflows/build-rpm.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   build-rpm:
     name: Build RPM package for Linux
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +41,7 @@ jobs:
 
         sudo apt-get update
 
-        sudo apt-get install --no-install-recommends --yes -V \
+        sudo timeout 10m apt-get install --no-install-recommends --yes -V \
             gettext \
             gir1.2-gdkpixbuf-2.0 \
             gir1.2-glib-2.0 \
@@ -57,7 +58,7 @@ jobs:
             librsvg2-common
 
         if ${use_deadsnakes}; then
-            sudo apt-get install --no-install-recommends --yes -V \
+            sudo timeout 10m apt-get install --no-install-recommends --yes -V \
                 python${PYVER} \
                 python${PYVER}-dev \
                 python${PYVER}-venv

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   pre-commit:
     name: Run pre-commit
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   run-tests:
     name: Run the test suite
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +33,7 @@ jobs:
       run: |
         set -x
         sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes -V \
+        sudo timeout 10m apt-get install --no-install-recommends --yes -V \
             gettext \
             gir1.2-gdkpixbuf-2.0 \
             gir1.2-glib-2.0 \

--- a/.github/workflows/windows-build-msys.yml
+++ b/.github/workflows/windows-build-msys.yml
@@ -16,6 +16,7 @@ on:
 jobs:
   checks:
     name: Build for Windows
+    timeout-minutes: 15
     runs-on: windows-2022
     defaults:
       run:


### PR DESCRIPTION
Sibling of https://github.com/libexpat/libexpat/pull/1311

@gbtami I believe we have seen CI runs here also where CI timed out after many hours of trying `sudo apt-get install` with a turtle-speed slow mirror. This pull request would turn that into failing way earlier. What do you think?